### PR TITLE
Refactor: update the README for the basic-panel example

### DIFF
--- a/examples/basic-panel/README.md
+++ b/examples/basic-panel/README.md
@@ -16,16 +16,14 @@ Use panel plugins when you want to do things like visualize data returned by dat
    yarn install
    ```
 
-2. Build plugin in development mode or run in watch mode
+2. Build plugin in development mode and run inside Grafana using Docker
 
    ```bash
+   # Start watching for changes
    yarn dev
-   ```
 
-   or
-
-   ```bash
-   yarn watch
+   # Run Grafana inside a docker container in a separate session
+   docker-compose up
    ```
 
 3. Build plugin in production mode


### PR DESCRIPTION
**What changed?**

Updated the README for the `basic-panel` example ([View new version](https://github.com/grafana/grafana-plugin-examples/blob/leventebalogh/update-basic-panel/examples/basic-panel/README.md))

- [x] updated the README to mention "panels" instead of "datasources".
- [x] added a note on how to run the example inside Grafana using Docker