### PR TITLE
Docs: update the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This repository contains example plugins to showcase different use cases.
 
 ## App plugins
 
-- [app-basic](examples/app-basic) demonstrates how to build a basic app plugin that uses custom routing.
+| Example                                           | Description                                                                                                                              |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [app-basic](examples/app-basic)                   | demonstrates how to build a basic app plugin that uses custom routing.              |
 
 ## Panel plugins
 


### PR DESCRIPTION
### What changed?
The first group of examples (app plugins) was accidentally not updated to be formatted to use a table layout. Fixing it now.

[View updated README](https://github.com/grafana/grafana-plugin-examples/tree/leventebalogh/update-readme#readme)