### PR TITLE
Dependabot: disable for NPM

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,4 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
### Why?

The examples in this repository are going to be updated manually (the dependencies have to be in sync with the ones used in Grafana to make sure everything is still working).