### PR TITLE
Basic App: solve weird redirect issues

### DIFF
--- a/examples/app-basic/src/components/Routes/Routes.tsx
+++ b/examples/app-basic/src/components/Routes/Routes.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Route, Switch, Redirect } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import { PageOne } from 'pages/PageOne';
 import { PageTwo } from 'pages/PageTwo';
 import { PageThree } from 'pages/PageThree';
@@ -12,7 +12,6 @@ export const Routes = () => {
 
   return (
     <Switch>
-      <Route exact path={prefixRoute(ROUTES.One)} component={PageOne} />
       <Route exact path={prefixRoute(ROUTES.Two)} component={PageTwo} />
       <Route exact path={prefixRoute(`${ROUTES.Three}/:id?`)} component={PageThree} />
 
@@ -20,9 +19,7 @@ export const Routes = () => {
       <Route exact path={prefixRoute(ROUTES.Four)} component={PageFour} />
 
       {/* Default page */}
-      <Route exact path="*">
-        <Redirect to={prefixRoute(ROUTES.One)} />
-      </Route>
+      <Route component={PageOne} />
     </Switch>
   );
 };


### PR DESCRIPTION
### What changed?

We noticed a weird issue when trying to navigate between certain app plugins in Grafana: the URL was flickering but the actual navigation never or rarely happened. 

The reason for that was that we had a `<Redirect>` component (for serving a "base url") initiating a redirect every time
the plugin was rendered, and like that it was overriding navigation happening between app plugins. 

The best solution to this problem would be if the app plugin would never render again after we are "navigating away" from it, and this would need to be fixed in the core wrapper. However as this is not straightforward to fix and takes more time we wanted to "attack" the problem from multiple angles and make the plugins more robust as well.

https://user-images.githubusercontent.com/9974811/165693674-8f4f25cd-9bd6-4ab5-af79-78574b2e2bee.mov