### PR TITLE
Fix e2e tests for datasource-basic example and remove cypress docker

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Start Docker container using expected version of grafana
         run: |
-          docker run -d -p 3000:3000 --name grafana -v ${PWD}/dist:/var/lib/grafana/plugins/$PLUGIN_ID -v ${PWD}/provisioning:/etc/grafana/provisioning -e GF_DEFAULT_APP_MODE -e GF_INSTALL_PLUGINS -e GF_AUTH_ANONYMOUS_ORG_ROLE -e GF_AUTH_ANONYMOUS_ENABLED -e GF_AUTH_BASIC_ENABLED grafana/grafana:$EXPECTED_GRAFANA_VERSION
+          docker run -p 3000:3000 --name grafana -v ${PWD}/dist:/var/lib/grafana/plugins/$PLUGIN_ID -v ${PWD}/provisioning:/etc/grafana/provisioning -e GF_DEFAULT_APP_MODE -e GF_INSTALL_PLUGINS -e GF_AUTH_ANONYMOUS_ORG_ROLE -e GF_AUTH_ANONYMOUS_ENABLED -e GF_AUTH_BASIC_ENABLED grafana/grafana:$EXPECTED_GRAFANA_VERSION
         working-directory: ${{ matrix.pluginDir }}
 
       ## Expected Version Tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -92,6 +92,14 @@ jobs:
           yarn build
         working-directory: ${{ matrix.pluginDir }}
 
+      - name: Build plugin backend
+        uses: magefile/mage-action@v1
+        with:
+          version: latest
+          args: -v build:linux
+          workdir: ${{ matrix.pluginDir }}
+        if: steps.backend-check.outputs.MAGEFILE_EXISTS == 'true'
+
       # Canary versions live at grafana/grafana-dev
       - name: Start Docker container using canary version of grafana
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,79 +73,6 @@ jobs:
           echo "CANARY_VERSION=$(npm view @grafana/ui dist-tags.canary)" >> $GITHUB_ENV
         working-directory: ${{ matrix.pluginDir }}
 
-      - name: Start Docker container using expected version of grafana
-        run: |
-          docker run -p 3000:3000 --name grafana -v ${PWD}/dist:/var/lib/grafana/plugins/$PLUGIN_ID -v ${PWD}/provisioning:/etc/grafana/provisioning -e GF_DEFAULT_APP_MODE -e GF_INSTALL_PLUGINS -e GF_AUTH_ANONYMOUS_ORG_ROLE -e GF_AUTH_ANONYMOUS_ENABLED -e GF_AUTH_BASIC_ENABLED grafana/grafana:$EXPECTED_GRAFANA_VERSION
-        working-directory: ${{ matrix.pluginDir }}
-
-      ## Expected Version Tests
-      ## Runs the plugin tests against the minimum compatible version of Grafana defined in its plugin.json.
-      - name: Start Integration tests using expected versions
-        id: expected-version-tests
-        continue-on-error: true
-        run: |
-          yarn e2e
-        working-directory: ${{ matrix.pluginDir }}
-
-      - name: Uploading artifacts for tests with expected versions
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{steps.example-name.outputs.result}}-expected-version-tests
-          path: |
-            ${{ matrix.pluginDir }}/cypress/screenshots
-            ${{ matrix.pluginDir }}/cypress/videos
-            ${{ matrix.pluginDir }}/cypress/report.json
-          retention-days: 3
-        if: steps.expected-version-tests.outcome != 'success'
-
-      - name: Failing build due to test failures (expected versions)
-        run: exit 1
-        if: steps.expected-version-tests.outcome != 'success'
-
-      - name: Stop and remove Docker container
-        run: |
-          docker stop grafana && docker rm grafana
-        working-directory: ${{ matrix.pluginDir }}
-
-      ## Latest Version Tests
-      ## Runs the plugin tests against the latest stable version of Grafana.
-      - name: Build plugin with latest version of e2e libraries
-        run: |
-          yarn upgrade @grafana/e2e-selectors @grafana/e2e --latest
-        working-directory: ${{ matrix.pluginDir }}
-
-      - name: Start Docker container using latest version of grafana
-        run: |
-          docker run -d -p 3000:3000 --name grafana -v ${PWD}/dist:/var/lib/grafana/plugins/$PLUGIN_ID -v ${PWD}/provisioning:/etc/grafana/provisioning -e GF_DEFAULT_APP_MODE -e GF_INSTALL_PLUGINS -e GF_AUTH_ANONYMOUS_ORG_ROLE -e GF_AUTH_ANONYMOUS_ENABLED -e GF_AUTH_BASIC_ENABLED grafana/grafana:latest
-        working-directory: ${{ matrix.pluginDir }}
-
-      - name: Start Integration tests using latest version of Grafana
-        id: latest-version-tests
-        continue-on-error: true
-        run: |
-          yarn e2e
-        working-directory: ${{ matrix.pluginDir }}
-
-      - name: Uploading artifacts for tests with latest version of Grafana
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{steps.example-name.outputs.result}}-latest-version-tests
-          path: |
-            ${{ matrix.pluginDir }}/cypress/screenshots
-            ${{ matrix.pluginDir }}/cypress/videos
-            ${{ matrix.pluginDir }}/cypress/report.json
-          retention-days: 3
-        if: steps.latest-version-tests.outcome != 'success'
-
-      - name: Failing build due to test failures (latest version of Grafana)
-        run: exit 1
-        if: steps.latest-version-tests.outcome != 'success'
-
-      - name: Stop and remove Docker container
-        run: |
-          docker stop grafana && docker rm grafana
-        working-directory: ${{ matrix.pluginDir }}
-
       ## Canary Version Tests
       ## Runs the plugin tests against the latest build of Grafana main branch.
 
@@ -168,7 +95,7 @@ jobs:
       # Canary versions live at grafana/grafana-dev
       - name: Start Docker container using canary version of grafana
         run: |
-          docker run -d -p 3000:3000 --name grafana -v ${PWD}/dist:/var/lib/grafana/plugins/$PLUGIN_ID -v ${PWD}/provisioning:/etc/grafana/provisioning -e GF_DEFAULT_APP_MODE -e GF_INSTALL_PLUGINS -e GF_AUTH_ANONYMOUS_ORG_ROLE -e GF_AUTH_ANONYMOUS_ENABLED -e GF_AUTH_BASIC_ENABLED grafana/grafana-dev:$CANARY_VERSION
+          docker run -p 3000:3000 --name grafana -v ${PWD}/dist:/var/lib/grafana/plugins/$PLUGIN_ID -v ${PWD}/provisioning:/etc/grafana/provisioning -e GF_DEFAULT_APP_MODE -e GF_INSTALL_PLUGINS -e GF_AUTH_ANONYMOUS_ORG_ROLE -e GF_AUTH_ANONYMOUS_ENABLED -e GF_AUTH_BASIC_ENABLED grafana/grafana-dev:$CANARY_VERSION
         working-directory: ${{ matrix.pluginDir }}
 
       - name: Start Integration tests using canary version of Grafana

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,6 +73,79 @@ jobs:
           echo "CANARY_VERSION=$(npm view @grafana/ui dist-tags.canary)" >> $GITHUB_ENV
         working-directory: ${{ matrix.pluginDir }}
 
+      - name: Start Docker container using expected version of grafana
+        run: |
+          docker run -d -p 3000:3000 --name grafana -v ${PWD}/dist:/var/lib/grafana/plugins/$PLUGIN_ID -v ${PWD}/provisioning:/etc/grafana/provisioning -e GF_DEFAULT_APP_MODE -e GF_INSTALL_PLUGINS -e GF_AUTH_ANONYMOUS_ORG_ROLE -e GF_AUTH_ANONYMOUS_ENABLED -e GF_AUTH_BASIC_ENABLED grafana/grafana:$EXPECTED_GRAFANA_VERSION
+        working-directory: ${{ matrix.pluginDir }}
+
+      ## Expected Version Tests
+      ## Runs the plugin tests against the minimum compatible version of Grafana defined in its plugin.json.
+      - name: Start Integration tests using expected versions
+        id: expected-version-tests
+        continue-on-error: true
+        run: |
+          yarn e2e
+        working-directory: ${{ matrix.pluginDir }}
+
+      - name: Uploading artifacts for tests with expected versions
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{steps.example-name.outputs.result}}-expected-version-tests
+          path: |
+            ${{ matrix.pluginDir }}/cypress/screenshots
+            ${{ matrix.pluginDir }}/cypress/videos
+            ${{ matrix.pluginDir }}/cypress/report.json
+          retention-days: 3
+        if: steps.expected-version-tests.outcome != 'success'
+
+      - name: Failing build due to test failures (expected versions)
+        run: exit 1
+        if: steps.expected-version-tests.outcome != 'success'
+
+      - name: Stop and remove Docker container
+        run: |
+          docker stop grafana && docker rm grafana
+        working-directory: ${{ matrix.pluginDir }}
+
+      ## Latest Version Tests
+      ## Runs the plugin tests against the latest stable version of Grafana.
+      - name: Build plugin with latest version of e2e libraries
+        run: |
+          yarn upgrade @grafana/e2e-selectors @grafana/e2e --latest
+        working-directory: ${{ matrix.pluginDir }}
+
+      - name: Start Docker container using latest version of grafana
+        run: |
+          docker run -d -p 3000:3000 --name grafana -v ${PWD}/dist:/var/lib/grafana/plugins/$PLUGIN_ID -v ${PWD}/provisioning:/etc/grafana/provisioning -e GF_DEFAULT_APP_MODE -e GF_INSTALL_PLUGINS -e GF_AUTH_ANONYMOUS_ORG_ROLE -e GF_AUTH_ANONYMOUS_ENABLED -e GF_AUTH_BASIC_ENABLED grafana/grafana:latest
+        working-directory: ${{ matrix.pluginDir }}
+
+      - name: Start Integration tests using latest version of Grafana
+        id: latest-version-tests
+        continue-on-error: true
+        run: |
+          yarn e2e
+        working-directory: ${{ matrix.pluginDir }}
+
+      - name: Uploading artifacts for tests with latest version of Grafana
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{steps.example-name.outputs.result}}-latest-version-tests
+          path: |
+            ${{ matrix.pluginDir }}/cypress/screenshots
+            ${{ matrix.pluginDir }}/cypress/videos
+            ${{ matrix.pluginDir }}/cypress/report.json
+          retention-days: 3
+        if: steps.latest-version-tests.outcome != 'success'
+
+      - name: Failing build due to test failures (latest version of Grafana)
+        run: exit 1
+        if: steps.latest-version-tests.outcome != 'success'
+
+      - name: Stop and remove Docker container
+        run: |
+          docker stop grafana && docker rm grafana
+        working-directory: ${{ matrix.pluginDir }}
+
       ## Canary Version Tests
       ## Runs the plugin tests against the latest build of Grafana main branch.
 
@@ -103,7 +176,7 @@ jobs:
       # Canary versions live at grafana/grafana-dev
       - name: Start Docker container using canary version of grafana
         run: |
-          docker run -p 3000:3000 --name grafana -v ${PWD}/dist:/var/lib/grafana/plugins/$PLUGIN_ID -v ${PWD}/provisioning:/etc/grafana/provisioning -e GF_DEFAULT_APP_MODE -e GF_INSTALL_PLUGINS -e GF_AUTH_ANONYMOUS_ORG_ROLE -e GF_AUTH_ANONYMOUS_ENABLED -e GF_AUTH_BASIC_ENABLED grafana/grafana-dev:$CANARY_VERSION
+          docker run -d -p 3000:3000 --name grafana -v ${PWD}/dist:/var/lib/grafana/plugins/$PLUGIN_ID -v ${PWD}/provisioning:/etc/grafana/provisioning -e GF_DEFAULT_APP_MODE -e GF_INSTALL_PLUGINS -e GF_AUTH_ANONYMOUS_ORG_ROLE -e GF_AUTH_ANONYMOUS_ENABLED -e GF_AUTH_BASIC_ENABLED grafana/grafana-dev:$CANARY_VERSION
         working-directory: ${{ matrix.pluginDir }}
 
       - name: Start Integration tests using canary version of Grafana

--- a/examples/datasource-basic/cypress.json
+++ b/examples/datasource-basic/cypress.json
@@ -1,4 +1,7 @@
 {
-    "video": false,
-    "reporter": "spec"
+  "video": false,
+  "reporter": "spec",
+  "retries": {
+    "runMode": 2
+  }
 }

--- a/examples/datasource-basic/package.json
+++ b/examples/datasource-basic/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "build": "TS_NODE_PROJECT=\"./.config/webpack/tsconfig.webpack.json\" webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "TS_NODE_PROJECT=\"./.config/webpack/tsconfig.webpack.json\" webpack -w -c ./.config/webpack/webpack.config.ts --env development",
-    "e2e": "docker run --rm --add-host=host.docker.internal:host-gateway --volume $(pwd):/e2e --workdir /e2e --env='CYPRESS_HOST=host.docker.internal' --env='CYPRESS_BASE_URL=http://host.docker.internal:3000' --entrypoint '/bin/bash' cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97 -c './node_modules/.bin/cypress install && yarn grafana-e2e run'",
-    "e2e:update": "docker run --rm --add-host=host.docker.internal:host-gateway --volume $(pwd):/e2e --workdir /e2e --env='CYPRESS_HOST=host.docker.internal' --env='CYPRESS_BASE_URL=http://host.docker.internal:3000' --entrypoint '/bin/bash' cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97 -c './node_modules/.bin/cypress install && yarn grafana-e2e run --update-screenshots'",
+    "e2e": "yarn cypress install && TZ=UTC yarn grafana-e2e run",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
* Removes the usage of docker to run cypress
* Adds retries to cypress for flaky test
* Sets a timezone to run cypress to prevent local timezone issues.