### PR TITLE
Switching from set-output to GITHUB_OUTPUT and reducing unnecessary runs

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -1,6 +1,7 @@
 name: Build all plugins
 on: pull_request
-
+concurrency:
+  group: build-all-${{ github.ref }}
 jobs:
   directories:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -2,6 +2,7 @@ name: Build all plugins
 on: pull_request
 concurrency:
   group: build-all-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   directories:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: set-plugin-dirs
-        run: echo "::set-output name=pluginDirs::$(find ./examples -name package.json -type f -print | xargs grep -l '"e2e":' | xargs -n 1 dirname | jq -R -s -c 'split("\n")[:-1]')"
+        run: echo "pluginDirs=$(find ./examples -name package.json -type f -print | xargs grep -l '"e2e":' | xargs -n 1 dirname | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
   run-integration-tests:
     needs: setup-matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,7 @@
 name: integration tests
 on: pull_request
-
+concurrency:
+  group: integration-tests-${{ github.ref }}
 jobs:
   setup-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set the name of the plugin-example to be tested
         id: example-name
         run: |
-          echo "::set-output name=PLUGIN_NAME::$(basename ${{ matrix.pluginDir }})"
+          echo "PLUGIN_NAME=$(basename ${{ matrix.pluginDir }})" >> $GITHUB_OUTPUT
 
       - name: Restore yarn cache
         uses: actions/cache@v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,6 +2,7 @@ name: integration tests
 on: pull_request
 concurrency:
   group: integration-tests-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   setup-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Why?
set-output is deprecated https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR is:
- switching to using the new format
- additionally reduces the amount of jobs running per open PR, as soon as something new is pushed the previous runs will be cancelled