### PR TITLE
chore(docker): remove comma in volumes

### DIFF
--- a/examples/datasource-basic/docker-compose.yaml
+++ b/examples/datasource-basic/docker-compose.yaml
@@ -10,5 +10,5 @@ services:
     ports:
       - 3000:3000/tcp
     volumes:
-      - ./dist:/var/lib/grafana/plugins/basic-datasource,
+      - ./dist:/var/lib/grafana/plugins/basic-datasource
       - ./provisioning:/etc/grafana/provisioning

--- a/examples/datasource-http/docker-compose.yaml
+++ b/examples/datasource-http/docker-compose.yaml
@@ -3,12 +3,12 @@ version: '3.0'
 services:
   grafana:
     container_name: 'http'
-    build: 
+    build:
       context: ./.config
       args:
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp
     volumes:
-      - ./dist:/var/lib/grafana/plugins/http,
+      - ./dist:/var/lib/grafana/plugins/http
       - ./provisioning:/etc/grafana/provisioning

--- a/examples/datasource-streaming-websocket/streaming-websocket-plugin/docker-compose.yaml
+++ b/examples/datasource-streaming-websocket/streaming-websocket-plugin/docker-compose.yaml
@@ -3,12 +3,12 @@ version: '3.0'
 services:
   grafana:
     container_name: 'example'
-    build: 
+    build:
       context: ./.config
       args:
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp
     volumes:
-      - ./dist:/var/lib/grafana/plugins/example,
+      - ./dist:/var/lib/grafana/plugins/example
       - ./provisioning:/etc/grafana/provisioning

--- a/examples/panel-basic/docker-compose.yaml
+++ b/examples/panel-basic/docker-compose.yaml
@@ -12,5 +12,5 @@ services:
     ports:
       - 3000:3000/tcp
     volumes:
-      - ./dist:/var/lib/grafana/plugins/basic-panel,
+      - ./dist:/var/lib/grafana/plugins/basic-panel
       - ./provisioning:/etc/grafana/provisioning

--- a/examples/panel-datalinks/docker-compose.yaml
+++ b/examples/panel-datalinks/docker-compose.yaml
@@ -10,5 +10,5 @@ services:
     ports:
       - 3000:3000/tcp
     volumes:
-      - ./dist:/var/lib/grafana/plugins/datalinks-panel,
+      - ./dist:/var/lib/grafana/plugins/datalinks-panel
       - ./provisioning:/etc/grafana/provisioning

--- a/examples/panel-flot/docker-compose.yaml
+++ b/examples/panel-flot/docker-compose.yaml
@@ -3,12 +3,12 @@ version: '3.0'
 services:
   grafana:
     container_name: 'example'
-    build: 
+    build:
       context: ./.config
       args:
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp
     volumes:
-      - ./dist:/var/lib/grafana/plugins/example,
+      - ./dist:/var/lib/grafana/plugins/example
       - ./provisioning:/etc/grafana/provisioning

--- a/examples/panel-frame-select/docker-compose.yaml
+++ b/examples/panel-frame-select/docker-compose.yaml
@@ -3,12 +3,12 @@ version: '3.0'
 services:
   grafana:
     container_name: 'example'
-    build: 
+    build:
       context: ./.config
       args:
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp
     volumes:
-      - ./dist:/var/lib/grafana/plugins/example,
+      - ./dist:/var/lib/grafana/plugins/example
       - ./provisioning:/etc/grafana/provisioning

--- a/examples/panel-plotly/docker-compose.yaml
+++ b/examples/panel-plotly/docker-compose.yaml
@@ -3,12 +3,12 @@ version: '3.0'
 services:
   grafana:
     container_name: 'example'
-    build: 
+    build:
       context: ./.config
       args:
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp
     volumes:
-      - ./dist:/var/lib/grafana/plugins/example,
+      - ./dist:/var/lib/grafana/plugins/example
       - ./provisioning:/etc/grafana/provisioning

--- a/examples/panel-scatterplot/docker-compose.yaml
+++ b/examples/panel-scatterplot/docker-compose.yaml
@@ -3,12 +3,12 @@ version: '3.0'
 services:
   grafana:
     container_name: 'example'
-    build: 
+    build:
       context: ./.config
       args:
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp
     volumes:
-      - ./dist:/var/lib/grafana/plugins/example,
+      - ./dist:/var/lib/grafana/plugins/example
       - ./provisioning:/etc/grafana/provisioning

--- a/examples/panel-visx/docker-compose.yaml
+++ b/examples/panel-visx/docker-compose.yaml
@@ -3,12 +3,12 @@ version: '3.0'
 services:
   grafana:
     container_name: 'visx'
-    build: 
+    build:
       context: ./.config
       args:
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp
     volumes:
-      - ./dist:/var/lib/grafana/plugins/visx,
+      - ./dist:/var/lib/grafana/plugins/visx
       - ./provisioning:/etc/grafana/provisioning


### PR DESCRIPTION
Just a small fix. 😃
This comma is not supposed to be there, and it is not an optional trailing comma.