### PR TITLE
Fix: HTTP backend example: Removed double defer resp.Body.Close()

### DIFF
--- a/examples/datasource-http-backend/pkg/plugin/datasource.go
+++ b/examples/datasource-http-backend/pkg/plugin/datasource.go
@@ -97,7 +97,6 @@ func (d *Datasource) query(ctx context.Context, pCtx backend.PluginContext, quer
 			log.DefaultLogger.Error("query: failed to close response body", "err", err.Error())
 		}
 	}()
-	defer resp.Body.Close()
 
 	// Make sure the response was successful
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
In the http backend example, `resp.Body.Close()` was accidentally called twice in `query`