### PR TITLE
Datasource-Basic: Improve error handling

### DIFF
--- a/examples/datasource-basic/pkg/plugin/datasource.go
+++ b/examples/datasource-basic/pkg/plugin/datasource.go
@@ -62,15 +62,7 @@ func (ds *Datasource) QueryData(ctx context.Context, req *backend.QueryDataReque
 	response := backend.NewQueryDataResponse()
 
 	// loop over queries and execute them individually.
-	for i, q := range req.Queries {
-		if i%2 != 0 {
-			// Just to demonstrate how to return an error with a custom status code.
-			response.Responses[q.RefID] = backend.ErrDataResponse(
-				backend.StatusBadRequest,
-				"user friendly error, excluding any sensitive information",
-			)
-			continue
-		}
+	for _, q := range req.Queries {
 		res := query.RunQuery(ctx, *ds.settings, q)
 
 		// save the response in a hashmap

--- a/examples/datasource-basic/pkg/query/runner.go
+++ b/examples/datasource-basic/pkg/query/runner.go
@@ -3,7 +3,6 @@ package query
 import (
 	"context"
 	"encoding/json"
-
 	"github.com/grafana/basic-datasource/pkg/models"
 	"github.com/grafana/basic-datasource/pkg/query/scenario"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -16,17 +15,17 @@ func RunQuery(_ context.Context, settings models.PluginSettings, query backend.D
 	// Unmarshal the JSON into our queryModel.
 	var qm models.QueryModel
 
-	response.Error = json.Unmarshal(query.JSON, &qm)
-	if response.Error != nil {
-		return response
+	err := json.Unmarshal(query.JSON, &qm)
+	if err != nil {
+		return backend.ErrDataResponse(backend.StatusBadRequest, "json unmarshal: "+err.Error())
 	}
 
 	// Interpolate query so it can be run against your data source if it
 	// contains any macros.
 	macro := newQueryMacro(settings, query.TimeRange)
-	qm.RunnableQuery, response.Error = macro.Interpolate(qm.RawQuery)
-	if response.Error != nil {
-		return response
+	qm.RunnableQuery, err = macro.Interpolate(qm.RawQuery)
+	if err != nil {
+		return backend.ErrDataResponse(backend.StatusBadRequest, "macro interpolate: "+err.Error())
 	}
 
 	// We are not using the RunnableQuery in this example because we are generating


### PR DESCRIPTION
Improve 207 status error handling example in `datasource-basic` by returning actual errors on macro validation and json decoding rather than dummy ones outside of RunQuery.