### PR TITLE
Datasource-Http-Backend: Fix wrong plugin ID in Manage() call

### DIFF
--- a/examples/datasource-http-backend/pkg/main.go
+++ b/examples/datasource-http-backend/pkg/main.go
@@ -17,7 +17,7 @@ func main() {
 	// from Grafana to create different instances of SampleDatasource (per datasource
 	// ID). When datasource configuration changed Dispose method will be called and
 	// new datasource instance created using NewSampleDatasource factory.
-	if err := datasource.Manage("grafana-datasource-http-backend", plugin.NewDatasource, datasource.ManageOpts{}); err != nil {
+	if err := datasource.Manage("grafana-datasourcehttpbackend-datasource", plugin.NewDatasource, datasource.ManageOpts{}); err != nil {
 		log.DefaultLogger.Error(err.Error())
 		os.Exit(1)
 	}


### PR DESCRIPTION
Related to https://github.com/grafana/plugin-tools/pull/159 as this example plugin was scaffolded using `create-plugin`.