### PR TITLE
Datasource-http: Improve error handling and error messages

### DIFF
--- a/examples/datasource-http/src/DataSource.ts
+++ b/examples/datasource-http/src/DataSource.ts
@@ -41,11 +41,20 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
        * }
        */
       const datapoints = response.data.datapoints;
+      if (typeof datapoints === 'undefined') {
+        throw new Error('Remote endpoint reponse does not contain "datapoints" property.');
+      }
 
       const timestamps: number[] = [];
       const values: number[] = [];
 
       for (let i = 0; i < datapoints.length; i++) {
+        if (typeof datapoints[i].Time === 'undefined') {
+          throw new Error(`Data point ${i} does not contain "Time" property`);
+        }
+        if (typeof datapoints[i].Value === 'undefined') {
+          throw new Error(`Data point ${i} does not contain "Value" property`);
+        }
         timestamps.push(datapoints[i].Time);
         values.push(datapoints[i].Value);
       }
@@ -93,7 +102,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
       if (_.isString(err)) {
         message = err;
       } else if (isFetchError(err)) {
-        message += err.statusText ? err.statusText : defaultErrorMessage;
+        message = `Fetch error: ${err.statusText ? err.statusText : defaultErrorMessage}`;
         if (err.data && err.data.error && err.data.error.code) {
           message += ': ' + err.data.error.code + '. ' + err.data.error.message;
         }

--- a/examples/datasource-http/src/DataSource.ts
+++ b/examples/datasource-http/src/DataSource.ts
@@ -41,7 +41,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
        * }
        */
       const datapoints = response.data.datapoints;
-      if (typeof datapoints === 'undefined') {
+      if (datapoints === undefined) {
         throw new Error('Remote endpoint reponse does not contain "datapoints" property.');
       }
 
@@ -49,10 +49,10 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
       const values: number[] = [];
 
       for (let i = 0; i < datapoints.length; i++) {
-        if (typeof datapoints[i].Time === 'undefined') {
+        if (datapoints[i].Time === undefined) {
           throw new Error(`Data point ${i} does not contain "Time" property`);
         }
-        if (typeof datapoints[i].Value === 'undefined') {
+        if (datapoints[i].Value === undefined) {
           throw new Error(`Data point ${i} does not contain "Value" property`);
         }
         timestamps.push(datapoints[i].Time);
@@ -102,7 +102,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
       if (_.isString(err)) {
         message = err;
       } else if (isFetchError(err)) {
-        message = `Fetch error: ${err.statusText ? err.statusText : defaultErrorMessage}`;
+        message = 'Fetch error: ' + (err.statusText ? err.statusText : defaultErrorMessage);
         if (err.data && err.data.error && err.data.error.code) {
           message += ': ' + err.data.error.code + '. ' + err.data.error.message;
         }


### PR DESCRIPTION
Improves error handling and error messages in the datasource-http example.
No 207-related changes to do, because the datasource does not have a backend.

Related to #109 