### PR TITLE
Fix readme titles to match the plugin validator

### DIFF
--- a/examples/app-basic/README.md
+++ b/examples/app-basic/README.md
@@ -1,4 +1,4 @@
-# Basic App Plugin
+# Grafana App Plugin Template
 
 This example demonstrates how to build a basic app plugin for Grafana that uses custom routing.
 
@@ -13,21 +13,21 @@ App plugins can let you create a custom out-of-the-box monitoring experience by 
 ---
 
 ## Guides in this example
- 
-|                                                  **Example**                                                        |          **Source**         |
-|---------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| [How to enable the tab navigation bar?](#how-to-enable-the-tab-navigation-bar)                                      |   [utils.routing.ts], [constants.ts#L17] |
-| [How to add a custom route?](#how-to-add-a-custom-route)                                                            |   [Routes.tsx], [constants.ts#L6]       |
-| [How to add a custom route with URL parameters?](#how-to-add-a-custom-route-with-url-parameters)                    |   [Routes.tsx], [PageThree.tsx] |
-| [How to create a full-width page with no navigation bar?](#how-to-create-a-full-width-page-with-no-navigation-bar)  |   [utils.routing.ts#L25] |
-| [How to add custom styling to your components?](#how-to-add-custom-styling-to-your-components)                      |   [PageFour.tsx] |
-| [How to use the Grafana theme in your components?](#how-to-use-the-grafana-theme-in-your-components)                |   [PageFour.tsx#L25] |
-| [How to add menu items to the left sidebar?](#how-to-add-menu-items-to-the-left-sidebar)                            |   [plugin.json] |
-| [How to add a configuration page to your app?](#how-to-add-a-configuration-page-to-your-app)                        |   [module.ts], [AppConfig.tsx]|
-| [How to add custom configuration values to your app?](#how-to-add-custom-configuration-values-to-your-app)          |   [AppConfig.tsx] |
-| [How to add configuration options for setting secrets?](#how-to-add-configuration-options-for-setting-secrets)      |   [AppConfig.tsx] |
-| [How to update the plugin settings using the API?](#how-to-update-the-plugin-settings-using-the-api)                |   [AppConfig.tsx] |
-| [How to access the saved secrets (proxying requests)?](#how-to-access-the-saved-secrets-proxying-requests)          |   [plugin.json] |
+
+| **Example**                                                                                                        | **Source**                             |
+| ------------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
+| [How to enable the tab navigation bar?](#how-to-enable-the-tab-navigation-bar)                                     | [utils.routing.ts], [constants.ts#L17] |
+| [How to add a custom route?](#how-to-add-a-custom-route)                                                           | [Routes.tsx], [constants.ts#L6]        |
+| [How to add a custom route with URL parameters?](#how-to-add-a-custom-route-with-url-parameters)                   | [Routes.tsx], [PageThree.tsx]          |
+| [How to create a full-width page with no navigation bar?](#how-to-create-a-full-width-page-with-no-navigation-bar) | [utils.routing.ts#L25]                 |
+| [How to add custom styling to your components?](#how-to-add-custom-styling-to-your-components)                     | [PageFour.tsx]                         |
+| [How to use the Grafana theme in your components?](#how-to-use-the-grafana-theme-in-your-components)               | [PageFour.tsx#L25]                     |
+| [How to add menu items to the left sidebar?](#how-to-add-menu-items-to-the-left-sidebar)                           | [plugin.json]                          |
+| [How to add a configuration page to your app?](#how-to-add-a-configuration-page-to-your-app)                       | [module.ts], [AppConfig.tsx]           |
+| [How to add custom configuration values to your app?](#how-to-add-custom-configuration-values-to-your-app)         | [AppConfig.tsx]                        |
+| [How to add configuration options for setting secrets?](#how-to-add-configuration-options-for-setting-secrets)     | [AppConfig.tsx]                        |
+| [How to update the plugin settings using the API?](#how-to-update-the-plugin-settings-using-the-api)               | [AppConfig.tsx]                        |
+| [How to access the saved secrets (proxying requests)?](#how-to-access-the-saved-secrets-proxying-requests)         | [plugin.json]                          |
 
 ### How to enable the tab navigation bar?
 
@@ -35,7 +35,7 @@ App plugins can let you create a custom out-of-the-box monitoring experience by 
 
 ![Navigation Bar](screenshots/screenshot-nav-bar.png)
 
-You can enable the tab navigation bar for your app plugin by passing a "nav-model" the `onNavChanged()` function that is passed in as a prop to your root App component. 
+You can enable the tab navigation bar for your app plugin by passing a "nav-model" the `onNavChanged()` function that is passed in as a prop to your root App component.
 If you don't want to get too much into the details you can just edit `NAVIGATION` object in [constants.ts#L17].
 
 **Setting the tabs in [constants.ts#L17]**
@@ -215,13 +215,13 @@ Below you can find source code for existing app plugins and other related docume
 - [How to sign a plugin?](https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/)
 
 [utils.routing.ts]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/utils/utils.routing.ts#L29
-[Routes.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/components/Routes/Routes.tsx#L17
-[PageThree.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/pages/PageThree/PageThree.tsx#L10
-[PageFour.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/pages/PageFour/PageFour.tsx#L22
-[PageFour.tsx#L25]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/pages/PageFour/PageFour.tsx#L25
-[utils.routing.ts#L25]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/utils/utils.routing.ts#L25
+[routes.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/components/Routes/Routes.tsx#L17
+[pagethree.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/pages/PageThree/PageThree.tsx#L10
+[pagefour.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/pages/PageFour/PageFour.tsx#L22
+[pagefour.tsx#l25]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/pages/PageFour/PageFour.tsx#L25
+[utils.routing.ts#l25]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/utils/utils.routing.ts#L25
 [plugin.json]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/plugin.json#L19
 [module.ts]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/module.ts#L5
-[AppConfig.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/components/AppConfig/AppConfig.tsx#L26
-[constants.ts#L6]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/constants.ts#L6
-[constants.ts#L17]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/constants.ts#L17
+[appconfig.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/components/AppConfig/AppConfig.tsx#L26
+[constants.ts#l6]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/constants.ts#L6
+[constants.ts#l17]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/constants.ts#L17

--- a/examples/app-basic/README.md
+++ b/examples/app-basic/README.md
@@ -214,14 +214,16 @@ Below you can find source code for existing app plugins and other related docume
 - [Plugin.json documentation](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/)
 - [How to sign a plugin?](https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/)
 
+<!-- prettier-ignore-start -->
 [utils.routing.ts]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/utils/utils.routing.ts#L29
-[routes.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/components/Routes/Routes.tsx#L17
-[pagethree.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/pages/PageThree/PageThree.tsx#L10
-[pagefour.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/pages/PageFour/PageFour.tsx#L22
-[pagefour.tsx#l25]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/pages/PageFour/PageFour.tsx#L25
-[utils.routing.ts#l25]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/utils/utils.routing.ts#L25
+[Routes.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/components/Routes/Routes.tsx#L17
+[PageThree.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/pages/PageThree/PageThree.tsx#L10
+[PageFour.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/pages/PageFour/PageFour.tsx#L22
+[PageFour.tsx#L25]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/pages/PageFour/PageFour.tsx#L25
+[utils.routing.ts#L25]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/utils/utils.routing.ts#L25
 [plugin.json]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/plugin.json#L19
 [module.ts]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/module.ts#L5
-[appconfig.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/components/AppConfig/AppConfig.tsx#L26
-[constants.ts#l6]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/constants.ts#L6
-[constants.ts#l17]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/constants.ts#L17
+[AppConfig.tsx]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/components/AppConfig/AppConfig.tsx#L26
+[constants.ts#L6]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/constants.ts#L6
+[constants.ts#L17]: https://github.com/grafana/grafana-plugin-examples/blob/master/examples/app-basic/src/constants.ts#L17
+<!-- prettier-ignore-end -->

--- a/examples/app-with-dashboards/README.md
+++ b/examples/app-with-dashboards/README.md
@@ -1,4 +1,4 @@
-# Grafana app plugin template
+# Grafana App Plugin Template
 
 This template is a starting point for building an app plugin for Grafana.
 
@@ -37,7 +37,7 @@ App plugins can let you create a custom out-of-the-box monitoring experience by 
    ```bash
    # Runs the tests and watches for changes
    yarn test
-   
+
    # Exists after running all the tests
    yarn lint:ci
    ```
@@ -51,9 +51,9 @@ App plugins can let you create a custom out-of-the-box monitoring experience by 
 6. Run the E2E tests (using Cypress)
 
    ```bash
-   # Spin up a Grafana instance first that we tests against 
+   # Spin up a Grafana instance first that we tests against
    yarn server
-   
+
    # Start the tests
    yarn e2e
    ```
@@ -62,13 +62,11 @@ App plugins can let you create a custom out-of-the-box monitoring experience by 
 
    ```bash
    yarn lint
-   
+
    # or
 
    yarn lint:fix
    ```
-
-
 
 ## Learn more
 

--- a/examples/datasource-http-backend/README.md
+++ b/examples/datasource-http-backend/README.md
@@ -1,4 +1,4 @@
-# Backend HTTP API data source
+# Grafana Data Source Plugin Template
 
 This example queries data from an HTTP API.
 

--- a/examples/datasource-http/README.md
+++ b/examples/datasource-http/README.md
@@ -1,3 +1,3 @@
-# HTTP API data source
+# Grafana Data Source Plugin Template
 
 This example queries data from an HTTP API.

--- a/examples/panel-basic/README.md
+++ b/examples/panel-basic/README.md
@@ -1,4 +1,4 @@
-# Basic Panel Plugin
+# Grafana Panel Plugin Template
 
 This is an example on how to build a basic panel plugin.
 

--- a/examples/panel-datalinks/README.md
+++ b/examples/panel-datalinks/README.md
@@ -1,4 +1,4 @@
-# Grafana panel plugin template
+# Grafana Panel Plugin Template
 
 This template is a starting point for building a panel plugin for Grafana.
 

--- a/examples/panel-flot/README.md
+++ b/examples/panel-flot/README.md
@@ -1,4 +1,4 @@
-# Flot panel
+# Grafana panel plugin template
 
 This example uses the [Flot](https://www.flotcharts.org) library to plot graphs.
 

--- a/examples/panel-frame-select/README.md
+++ b/examples/panel-frame-select/README.md
@@ -1,4 +1,4 @@
-# Frame select
+# Grafana Panel Plugin Template
 
 This example shows how you can set panel options based on the response from a data query.
 

--- a/examples/panel-plotly/README.md
+++ b/examples/panel-plotly/README.md
@@ -1,4 +1,4 @@
-# Plotly panel
+# Grafana Panel Plugin Template
 
 This example uses the [Plotly](https://plotly.com/) library to plot graphs.
 

--- a/examples/panel-scatterplot/README.md
+++ b/examples/panel-scatterplot/README.md
@@ -1,4 +1,3 @@
-# Scatterplot
+# Grafana Panel Plugin Template
 
 This is an example of visualizing a scatterplot using SVG and [D3.js](https://d3js.org/).
-

--- a/examples/panel-visx/README.md
+++ b/examples/panel-visx/README.md
@@ -1,4 +1,4 @@
-# visx
+# Grafana Panel Plugin Template
 
 This example uses visx to render an SVG graph.
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-plugin-examples/issues/121

To allow the [plugin validator](https://github.com/grafana/plugin-validator) automatically detect
wrong README.md files, they should follow a pattern described in #121

> Note to the reviewer
> Prettier applied in the `.md` files and some whitespaces changed. Please make sure to select "ignore whitespaces"
> when reviewing the code
