### PR TITLE
Remove default logging examples as their usage is prone to user error

### DIFF
--- a/examples/app-with-backend/pkg/plugin/app.go
+++ b/examples/app-with-backend/pkg/plugin/app.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
 	"net/http"
 )
@@ -46,10 +45,8 @@ func (a *App) Dispose() {
 
 // CheckHealth handles health checks sent from Grafana to the plugin.
 func (a *App) CheckHealth(_ context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	log.DefaultLogger.Info("health check request received")
 	return &backend.CheckHealthResult{
 		Status:  backend.HealthStatusOk,
 		Message: "ok",
 	}, nil
 }
-

--- a/examples/datasource-basic/pkg/plugin/datasource.go
+++ b/examples/datasource-basic/pkg/plugin/datasource.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/basic-datasource/pkg/query"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 // Make sure Datasource implements required interfaces. This is important to do
@@ -56,8 +55,6 @@ func (ds *Datasource) Dispose() {
 // The QueryDataResponse contains a map of RefID to the response for each query, and each response
 // contains Frames ([]*Frame).
 func (ds *Datasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	log.DefaultLogger.Debug("QueryData called", "queries", req.Queries)
-
 	// create response struct
 	response := backend.NewQueryDataResponse()
 
@@ -78,8 +75,6 @@ func (ds *Datasource) QueryData(ctx context.Context, req *backend.QueryDataReque
 // datasource configuration page which allows users to verify that
 // a datasource is working as expected.
 func (ds *Datasource) CheckHealth(_ context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	log.DefaultLogger.Debug("CheckHealth called")
-
 	var status = backend.HealthStatusOk
 	var message = "Data source is working"
 


### PR DESCRIPTION
Following some recent plugin reviews, it appears that we have some work to do to encourage best practices for logging

## TL;DR
### When logging, make sure you don't include any sensitive information in the message