### PR TITLE
HTTP Backend example: Add query input

### DIFF
--- a/examples/datasource-http-backend/cmd/server/service/service.go
+++ b/examples/datasource-http-backend/cmd/server/service/service.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"math"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -25,13 +26,22 @@ type dataPoint struct {
 
 // getMetrics is an handlerFunc that writes dummy metrics in JSON format
 // back to the client
-func getMetrics(w http.ResponseWriter, _ *http.Request) error {
+func getMetrics(w http.ResponseWriter, req *http.Request) error {
 	const pointsN = 1024
 	points := make([]dataPoint, pointsN)
+	multiplier := req.URL.Query().Get("multiplier")
+	multiplierInt := 1
+	if multiplier != "" {
+		var err error
+		multiplierInt, err = strconv.Atoi(multiplier)
+		if err != nil {
+			return err
+		}
+	}
 	for i := 0; i < pointsN; i++ {
 		ts := time.Now().Add(time.Second * time.Duration(-i)).UTC()
 		points[i].Time = ts
-		points[i].Value = math.Sin(float64(ts.Unix()) / 10)
+		points[i].Value = math.Sin(float64(ts.Unix())/10) * float64(multiplierInt)
 	}
 	w.Header().Add("Content-Type", "application/json")
 	return json.NewEncoder(w).Encode(metrics{

--- a/examples/datasource-http-backend/pkg/plugin/types.go
+++ b/examples/datasource-http-backend/pkg/plugin/types.go
@@ -12,3 +12,7 @@ type apiDataPoint struct {
 	Time  time.Time `json:"time"`
 	Value float64   `json:"value"`
 }
+
+type apiQuery struct {
+	Multiplier int `json:"multiplier"`
+}

--- a/examples/datasource-http-backend/src/components/QueryEditor.tsx
+++ b/examples/datasource-http-backend/src/components/QueryEditor.tsx
@@ -2,12 +2,22 @@ import React, { PureComponent } from 'react';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from '../datasource';
 import { MyDataSourceOptions, MyQuery } from '../types';
+import { HorizontalGroup, Input, Label } from '@grafana/ui';
 
 type Props = QueryEditorProps<DataSource, MyQuery, MyDataSourceOptions>;
 
 export class QueryEditor extends PureComponent<Props> {
   render() {
-    // No specific form for the query editor
-    return <div className="gf-form"></div>;
+    return (
+      <HorizontalGroup>
+        <Label>Multiplier</Label>
+        <Input
+          type="number"
+          label="Multiplier"
+          value={this.props.query.multiplier}
+          onChange={(e) => this.props.onChange({ ...this.props.query, multiplier: e.currentTarget.valueAsNumber })}
+        />
+      </HorizontalGroup>
+    );
   }
 }

--- a/examples/datasource-http-backend/src/datasource.ts
+++ b/examples/datasource-http-backend/src/datasource.ts
@@ -1,4 +1,4 @@
-import { DataSourceInstanceSettings } from '@grafana/data';
+import { CoreApp, DataSourceInstanceSettings } from '@grafana/data';
 
 import { MyQuery, MyDataSourceOptions } from './types';
 import { DataSourceWithBackend } from '@grafana/runtime';
@@ -6,5 +6,9 @@ import { DataSourceWithBackend } from '@grafana/runtime';
 export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions>) {
     super(instanceSettings);
+  }
+
+  getDefaultQuery(app: CoreApp): Partial<MyQuery> {
+    return { multiplier: 1 };
   }
 }

--- a/examples/datasource-http-backend/src/types.ts
+++ b/examples/datasource-http-backend/src/types.ts
@@ -1,5 +1,7 @@
 import { DataQuery, DataSourceJsonData } from '@grafana/data';
 
-export interface MyQuery extends DataQuery {}
+export interface MyQuery extends DataQuery {
+  multiplier: number;
+}
 
 export interface MyDataSourceOptions extends DataSourceJsonData {}


### PR DESCRIPTION
I noticed that Explore was not working for the this example. It turns out that Explore ignores queries that are "empty":

https://github.com/grafana/grafana/blob/main/public/app/core/utils/explore.ts#L346-L351

Even though it's marked as a _FIXME_, I thought it could be usefult to have some input in this example. That way it works with Explore:

![Screenshot from 2023-03-02 16-20-17](https://user-images.githubusercontent.com/4025665/222471698-cbe9e8b5-c6d1-4292-814e-427560f64415.png)

Is it an _overkill_? Probably yes, but at least is closer to a real-life example.