### PR TITLE
Fixed typo in examples/app-with-backend/pkg/plugin/resources.go

### DIFF
--- a/examples/app-with-backend/pkg/plugin/resources.go
+++ b/examples/app-with-backend/pkg/plugin/resources.go
@@ -15,7 +15,7 @@ func (a *App) handlePing(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	log.DefaultLogger.Info("ping recieved")
+	log.DefaultLogger.Info("ping received")
 	w.WriteHeader(http.StatusOK)
 }
 


### PR DESCRIPTION
Just a small typo fixed in examples/app-with-backend/pkg/plugin/resources.go