### PR TITLE
Build: disable e2e test recording to speed up CI

### DIFF
--- a/examples/app-with-backend/cypress.json
+++ b/examples/app-with-backend/cypress.json
@@ -1,0 +1,9 @@
+{
+    "video": false,
+    "videoCompression": false,
+    "screenshotOnRunFailure": true,
+    "reporter": "spec",
+    "retries": {
+        "runMode": 3
+    }
+}


### PR DESCRIPTION
Disabling the cypress video recording for the app-with-backend e2e tests to speed up the CI run.