### PR TITLE
WIP: App Plugin using react-router v5

### DIFF
--- a/examples/app-basic/src/components/Routes/Routes.tsx
+++ b/examples/app-basic/src/components/Routes/Routes.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import { PageOne } from '../../pages/PageOne';
 import { PageTwo } from '../../pages/PageTwo';
 import { PageThree } from '../../pages/PageThree';
@@ -12,11 +12,15 @@ export const Routes = () => {
 
   return (
     <Switch>
+      <Route exact path={prefixRoute(ROUTES.One)} component={PageOne} />
       <Route exact path={prefixRoute(ROUTES.Two)} component={PageTwo} />
       <Route exact path={prefixRoute(`${ROUTES.Three}/:id?`)} component={PageThree} />
 
       {/* Full-width page (this page will have no navigation bar) */}
       <Route exact path={prefixRoute(ROUTES.Four)} component={PageFour} />
+
+      {/* TEST! - Redirect inside a Switch */}
+      <Redirect to={'/connections/connect-data'} />
 
       {/* Default page */}
       <Route component={PageOne} />

--- a/examples/app-basic/src/constants.ts
+++ b/examples/app-basic/src/constants.ts
@@ -1,7 +1,6 @@
 import { NavModelItem } from '@grafana/data';
 import pluginJson from './plugin.json';
 
-
 export const PLUGIN_BASE_URL = `/a/${pluginJson.id}`;
 
 export enum ROUTES {
@@ -11,7 +10,7 @@ export enum ROUTES {
   Four = 'four',
 }
 
-export const NAVIGATION_TITLE = 'Basic App Plugin';
+export const NAVIGATION_TITLE = 'Basic App Plugin (React Router v5)';
 export const NAVIGATION_SUBTITLE = 'Some extra description...';
 
 // Add a navigation item for each route you would like to display in the navigation bar

--- a/examples/app-basic/src/pages/PageOne/PageOne.tsx
+++ b/examples/app-basic/src/pages/PageOne/PageOne.tsx
@@ -13,7 +13,14 @@ export const PageOne = () => {
     <div data-testid={testIds.pageOne.container}>
       This is page one.
       <div className={s.marginTop}>
-        <LinkButton data-testid={testIds.pageOne.navigateToFour} href={prefixRoute(ROUTES.Four)}>Full-width page example</LinkButton>
+        <LinkButton data-testid={testIds.pageOne.navigateToFour} href={prefixRoute(ROUTES.Four)}>
+          Full-width page example
+        </LinkButton>
+
+        {/* TEST! (Link to a non-existing route) */}
+        <LinkButton href={prefixRoute('non-existing')} className={s.marginLeft}>
+          404 route
+        </LinkButton>
       </div>
     </div>
   );
@@ -22,5 +29,8 @@ export const PageOne = () => {
 const getStyles = (theme: GrafanaTheme2) => ({
   marginTop: css`
     margin-top: ${theme.spacing(2)};
+  `,
+  marginLeft: css`
+    margin-left: ${theme.spacing(2)};
   `,
 });


### PR DESCRIPTION
**This PR is not intended to be merged, it is only created for testing purposes.** (It is not just a branch so we can add some docs next to it as well).

Related core Grafana PR: https://github.com/grafana/grafana/pull/66921

### What changed?
This branch is using `react-router-dom@5`, and adds a `<Redirect>` inside a `<Switch>`, something that would break in `react-router-dom@v6`. The goal is to test that a plugin using things like these would keep working if we start migrating to `react-router-dom@v6` in core Grafana. 

### How to test?
```bash
# Build the app plugin
$ git checkout leventebalogh/react-router-v5
$ yarn
$ yarn build

# Symlink the plugin to your local Grafana
$ ln -s <LOCAL_REPO_PATH>/examples/app-basic/dist <LOCAL_GRAFANA_PATH>/data/plugins/basic-app-plugin

# Run Grafana locally and enable the Basic App plugin! 
```
