### PR TITLE
Check latest Go version in ci, release and integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -69,6 +69,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: "~1.20"
+          check-latest: true
 
       - name: Install dependencies
         run: |

--- a/examples/app-with-dashboards/.github/workflows/ci.yml
+++ b/examples/app-with-dashboards/.github/workflows/ci.yml
@@ -65,9 +65,10 @@ jobs:
 
       - name: Setup Go environment
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: '~1.20'
+          check-latest: true
 
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'

--- a/examples/app-with-dashboards/.github/workflows/release.yml
+++ b/examples/app-with-dashboards/.github/workflows/release.yml
@@ -18,9 +18,10 @@ jobs:
           node-version: '14.x'
 
       - name: Setup Go environment
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: '~1.20'
+          check-latest: true
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path


### PR DESCRIPTION
Based on https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs v4 caching is enabled by default. Adding a check for the latest version in addition