### PR TITLE
Bumping grafanadependency version

### DIFF
--- a/examples/datasource-http-backend/src/plugin.json
+++ b/examples/datasource-http-backend/src/plugin.json
@@ -32,7 +32,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": "^9.1.2",
+    "grafanaDependency": ">=9.1.2",
     "plugins": []
   }
 }

--- a/examples/panel-datalinks/src/plugin.json
+++ b/examples/panel-datalinks/src/plugin.json
@@ -28,7 +28,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": "9.x.x",
+    "grafanaDependency": ">=9.1.2",
     "plugins": []
   }
 }


### PR DESCRIPTION
Changing `grafanaDependency` for the examples that had it locked down