### PR TITLE
Bumping docker compose files to make grafana_image flexible

### DIFF
--- a/examples/app-basic/.config/jest.config.js
+++ b/examples/app-basic/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/app-basic/docker-compose.yaml
+++ b/examples/app-basic/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp

--- a/examples/app-with-backend/.config/jest.config.js
+++ b/examples/app-with-backend/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/app-with-backend/docker-compose.yaml
+++ b/examples/app-with-backend/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.2.5}
     ports:
       - 3000:3000/tcp

--- a/examples/app-with-dashboards/.config/jest.config.js
+++ b/examples/app-with-dashboards/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/app-with-dashboards/docker-compose.yaml
+++ b/examples/app-with-dashboards/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.2.1}
     ports:
       - 3000:3000/tcp

--- a/examples/app-with-extension-point/.config/jest.config.js
+++ b/examples/app-with-extension-point/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/app-with-extension-point/docker-compose.yaml
+++ b/examples/app-with-extension-point/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-main}
     ports:
       - 3000:3000/tcp

--- a/examples/app-with-extensions/.config/jest.config.js
+++ b/examples/app-with-extensions/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/app-with-extensions/docker-compose.yaml
+++ b/examples/app-with-extensions/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-main}
     ports:
       - 3000:3000/tcp

--- a/examples/app-with-scenes/.config/jest.config.js
+++ b/examples/app-with-scenes/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/app-with-scenes/docker-compose.yaml
+++ b/examples/app-with-scenes/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.5.2}
     ports:
       - 3000:3000/tcp

--- a/examples/datasource-basic/.config/jest.config.js
+++ b/examples/datasource-basic/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/datasource-basic/docker-compose.yaml
+++ b/examples/datasource-basic/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp

--- a/examples/datasource-http-backend/.config/jest.config.js
+++ b/examples/datasource-http-backend/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/datasource-http-backend/docker-compose.yaml
+++ b/examples/datasource-http-backend/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp

--- a/examples/datasource-http/.config/jest.config.js
+++ b/examples/datasource-http/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/datasource-http/docker-compose.yaml
+++ b/examples/datasource-http/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp

--- a/examples/datasource-streaming-websocket/streaming-websocket-plugin/.config/jest.config.js
+++ b/examples/datasource-streaming-websocket/streaming-websocket-plugin/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/datasource-streaming-websocket/streaming-websocket-plugin/docker-compose.yaml
+++ b/examples/datasource-streaming-websocket/streaming-websocket-plugin/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp

--- a/examples/panel-basic/.config/jest.config.js
+++ b/examples/panel-basic/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/panel-basic/docker-compose.yaml
+++ b/examples/panel-basic/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     environment:
       - GF_INSTALL_PLUGINS=marcusolsson-static-datasource

--- a/examples/panel-datalinks/.config/jest.config.js
+++ b/examples/panel-datalinks/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/panel-datalinks/docker-compose.yaml
+++ b/examples/panel-datalinks/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp

--- a/examples/panel-flot/.config/jest.config.js
+++ b/examples/panel-flot/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/panel-flot/docker-compose.yaml
+++ b/examples/panel-flot/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp

--- a/examples/panel-frame-select/.config/jest.config.js
+++ b/examples/panel-frame-select/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/panel-frame-select/docker-compose.yaml
+++ b/examples/panel-frame-select/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp

--- a/examples/panel-plotly/.config/jest.config.js
+++ b/examples/panel-plotly/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/panel-plotly/docker-compose.yaml
+++ b/examples/panel-plotly/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp

--- a/examples/panel-scatterplot/.config/jest.config.js
+++ b/examples/panel-scatterplot/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/panel-scatterplot/docker-compose.yaml
+++ b/examples/panel-scatterplot/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp

--- a/examples/panel-visx/.config/jest.config.js
+++ b/examples/panel-visx/.config/jest.config.js
@@ -25,7 +25,7 @@ module.exports = {
     '^.+\\.(t|j)sx?$': [
       '@swc/jest',
       {
-        sourceMaps: true,
+        sourceMaps: 'inline',
         jsc: {
           parser: {
             syntax: 'typescript',

--- a/examples/panel-visx/docker-compose.yaml
+++ b/examples/panel-visx/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
     ports:
       - 3000:3000/tcp


### PR DESCRIPTION
Related to https://github.com/grafana/plugin-tools/pull/286

Changes:
- Bumping `.config` folders via `create-plugin` `update` command
- Adjusting `docker-compose.yml` files to make docker image flexible

This is a non breaking change as it will always just fallback to default. 