### PR TITLE
Fix datasource streaming websocket

### DIFF
--- a/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/DataSource.ts
+++ b/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/DataSource.ts
@@ -5,6 +5,7 @@ import {
   DataSourceApi,
   DataSourceInstanceSettings,
   FieldType,
+  LoadingState,
 } from '@grafana/data';
 import defaults from 'lodash/defaults';
 import { merge, Observable } from 'rxjs';
@@ -46,6 +47,7 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
           subscriber.next({
             data: [frame],
             key: query.refId,
+            state: LoadingState.Streaming,
           });
         };
       });

--- a/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/plugin.json
+++ b/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/plugin.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
-  "type": "panel",
+  "type": "datasource",
   "name": "Example",
   "id": "example-websocket-datasource",
   "info": {


### PR DESCRIPTION
This plugin example wasn't working out of the box.
This PR fix that by changing the plugin type to `datasource` and it also improves the code by adding the `LoadingState.Streaming` to panel state