### PR TITLE
Add update-backend-sdk.sh script

### DIFF
--- a/scripts/update-backend-sdk.sh
+++ b/scripts/update-backend-sdk.sh
@@ -8,14 +8,16 @@ fi
 
 SDK_TARGET="$1"
 
+# Keep track of base directory
+base=$(pwd)
+
 # Find go.mod files (backend plugins)
 files=$(find examples -type f -name "go.mod")
-
-base=$(pwd)
 
 # Iterate over each file and run `go get` to upgrade the grafana-plugin-sdk-go dependency
 for file in $files; do
   echo "Upgrading grafana-plugin-sdk-go to ${SDK_TARGET:-latest} in $file"
+  
   cd $(dirname "$file")
   if [ ! -z "$SDK_TARGET" ]; then
     go get "github.com/grafana/grafana-plugin-sdk-go@$SDK_TARGET"
@@ -23,5 +25,7 @@ for file in $files; do
     go get -u github.com/grafana/grafana-plugin-sdk-go
   fi
   go mod tidy
+
+  # Return to base directory
   cd "$base"
 done

--- a/scripts/update-backend-sdk.sh
+++ b/scripts/update-backend-sdk.sh
@@ -8,9 +8,6 @@ fi
 
 SDK_TARGET="${1:-latest}"
 
-# Keep track of base directory
-base=$(pwd)
-
 # Find go.mod files (backend plugins)
 files=$(find examples -type f -name "go.mod")
 
@@ -18,10 +15,10 @@ files=$(find examples -type f -name "go.mod")
 for file in $files; do
   echo "Upgrading grafana-plugin-sdk-go to $SDK_TARGET in $file"
 
-  cd $(dirname "$file")
+  pushd $(dirname "$file") || exit 1
   go get -u "github.com/grafana/grafana-plugin-sdk-go@$SDK_TARGET"
   go mod tidy
 
   # Return to base directory
-  cd "$base"
+  popd || exit 1
 done

--- a/scripts/update-backend-sdk.sh
+++ b/scripts/update-backend-sdk.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ "$1" == "--help" ]; then
+  echo "Usage: $0 [vX.Y.Z]"
+  echo "(defaults to latest version if not specified)"
+  exit 0
+fi
+
+SDK_TARGET="$1"
+
+# Find go.mod files (backend plugins)
+files=$(find examples -type f -name "go.mod")
+
+base=$(pwd)
+
+# Iterate over each file and run `go get` to upgrade the grafana-plugin-sdk-go dependency
+for file in $files; do
+  echo "Upgrading grafana-plugin-sdk-go to ${SDK_TARGET:-latest} in $file"
+  cd $(dirname "$file")
+  if [ ! -z "$SDK_TARGET" ]; then
+    go get "github.com/grafana/grafana-plugin-sdk-go@$SDK_TARGET"
+  else
+    go get -u github.com/grafana/grafana-plugin-sdk-go
+  fi
+  go mod tidy
+  cd "$base"
+done

--- a/scripts/update-backend-sdk.sh
+++ b/scripts/update-backend-sdk.sh
@@ -6,7 +6,7 @@ if [ "$1" == "--help" ]; then
   exit 0
 fi
 
-SDK_TARGET="$1"
+SDK_TARGET="${1:-latest}"
 
 # Keep track of base directory
 base=$(pwd)
@@ -16,14 +16,10 @@ files=$(find examples -type f -name "go.mod")
 
 # Iterate over each file and run `go get` to upgrade the grafana-plugin-sdk-go dependency
 for file in $files; do
-  echo "Upgrading grafana-plugin-sdk-go to ${SDK_TARGET:-latest} in $file"
-  
+  echo "Upgrading grafana-plugin-sdk-go to $SDK_TARGET in $file"
+
   cd $(dirname "$file")
-  if [ ! -z "$SDK_TARGET" ]; then
-    go get "github.com/grafana/grafana-plugin-sdk-go@$SDK_TARGET"
-  else
-    go get -u github.com/grafana/grafana-plugin-sdk-go
-  fi
+  go get -u "github.com/grafana/grafana-plugin-sdk-go@$SDK_TARGET"
   go mod tidy
 
   # Return to base directory

--- a/scripts/update-grafana-version.sh
+++ b/scripts/update-grafana-version.sh
@@ -105,3 +105,10 @@ for file in $files; do
         echo "Modified $file"
     fi
 done
+
+
+###############################################
+# Upgrade grafana-plugin-sdk-go to latest version
+###############################################
+
+./scripts/update-backend-sdk.sh


### PR DESCRIPTION
Adds a script to update backend sdk version in all backend plugins.

It can be used standalone, but it is also added to `update-grafana-version.sh` at the end.

```bash
╰─❯ ./scripts/update-backend-sdk.sh --help
Usage: ./scripts/update-backend-sdk.sh [vX.Y.Z]
(defaults to latest version if not specified)
```

