### PR TITLE
plugin-examples:  

### DIFF
--- a/examples/app-basic/package.json
+++ b/examples/app-basic/package.json
@@ -23,7 +23,7 @@
     "@grafana/e2e-selectors": "10.0.3",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/app-with-backend/package.json
+++ b/examples/app-with-backend/package.json
@@ -23,7 +23,7 @@
     "@grafana/e2e-selectors": "10.0.3",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/app-with-dashboards/package.json
+++ b/examples/app-with-dashboards/package.json
@@ -23,7 +23,7 @@
     "@grafana/e2e-selectors": "10.0.3",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/app-with-dashboards/src/components/AppConfig/AppConfig.tsx
+++ b/examples/app-with-dashboards/src/components/AppConfig/AppConfig.tsx
@@ -15,7 +15,7 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
   const { enabled, jsonData } = plugin.meta;
 
   return (
-    <div className="gf-form-group" data-testid={testIds.appConfig.container}>
+    <div data-testid={testIds.appConfig.container}>
       <div>
         {/* Enable the plugin */}
         <Legend>Enable / Disable</Legend>

--- a/examples/app-with-extension-point/package.json
+++ b/examples/app-with-extension-point/package.json
@@ -23,7 +23,7 @@
     "@grafana/e2e-selectors": "10.0.3",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/app-with-extensions/package.json
+++ b/examples/app-with-extensions/package.json
@@ -23,7 +23,7 @@
     "@grafana/e2e-selectors": "10.0.3",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/app-with-extensions/src/components/AppConfig/AppConfig.tsx
+++ b/examples/app-with-extensions/src/components/AppConfig/AppConfig.tsx
@@ -14,49 +14,47 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
   const { enabled, jsonData } = plugin.meta;
 
   return (
-    <div className="gf-form-group">
-      <div>
-        {/* Enable the plugin */}
-        <Legend>Enable / Disable</Legend>
-        {!enabled && (
-          <>
-            <div className={s.colorWeak}>The plugin is currently not enabled.</div>
-            <Button
-              className={s.marginTop}
-              variant="primary"
-              onClick={() =>
-                updatePluginAndReload(plugin.meta.id, {
-                  enabled: true,
-                  pinned: true,
-                  jsonData,
-                })
-              }
-            >
-              Enable plugin
-            </Button>
-          </>
-        )}
+    <div>
+      {/* Enable the plugin */}
+      <Legend>Enable / Disable </Legend>
+      {!enabled && (
+        <>
+          <div className={s.colorWeak}>The plugin is currently not enabled.</div>
+          <Button
+            className={s.marginTop}
+            variant="primary"
+            onClick={() =>
+              updatePluginAndReload(plugin.meta.id, {
+                enabled: true,
+                pinned: true,
+                jsonData,
+              })
+            }
+          >
+            Enable plugin
+          </Button>
+        </>
+      )}
 
-        {/* Disable the plugin */}
-        {enabled && (
-          <>
-            <div className={s.colorWeak}>The plugin is currently enabled.</div>
-            <Button
-              className={s.marginTop}
-              variant="destructive"
-              onClick={() =>
-                updatePluginAndReload(plugin.meta.id, {
-                  enabled: false,
-                  pinned: false,
-                  jsonData,
-                })
-              }
-            >
-              Disable plugin
-            </Button>
-          </>
-        )}
-      </div>
+      {/* Disable the plugin */}
+      {enabled && (
+        <>
+          <div className={s.colorWeak}>The plugin is currently enabled.</div>
+          <Button
+            className={s.marginTop}
+            variant="destructive"
+            onClick={() =>
+              updatePluginAndReload(plugin.meta.id, {
+                enabled: false,
+                pinned: false,
+                jsonData,
+              })
+            }
+          >
+            Disable plugin
+          </Button>
+        </>
+      )}
     </div>
   );
 };

--- a/examples/app-with-on-behalf-of-auth/package.json
+++ b/examples/app-with-on-behalf-of-auth/package.json
@@ -23,7 +23,7 @@
     "@grafana/e2e-selectors": "10.0.3",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.62",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/app-with-scenes/package.json
+++ b/examples/app-with-scenes/package.json
@@ -23,7 +23,7 @@
     "@grafana/e2e": "10.0.0",
     "@grafana/eslint-config": "^5.1.0",
     "@grafana/tsconfig": "^1.2.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/datasource-http-backend/package.json
+++ b/examples/datasource-http-backend/package.json
@@ -23,7 +23,7 @@
     "@grafana/e2e-selectors": "10.0.3",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/datasource-http-backend/src/components/ConfigEditor.tsx
+++ b/examples/datasource-http-backend/src/components/ConfigEditor.tsx
@@ -11,15 +11,11 @@ export class ConfigEditor extends PureComponent<Props, State> {
   render() {
     const { options } = this.props;
     return (
-      <div className="gf-form-group">
-        <div className="gf-form">
-          <DataSourceHttpSettings
-            defaultUrl="http://127.0.0.1:10000/metrics"
-            dataSourceConfig={options}
-            onChange={this.props.onOptionsChange}
-          />
-        </div>
-      </div>
+      <DataSourceHttpSettings
+        defaultUrl="http://127.0.0.1:10000/metrics"
+        dataSourceConfig={options}
+        onChange={this.props.onOptionsChange}
+      />
     );
   }
 }

--- a/examples/datasource-http/package.json
+++ b/examples/datasource-http/package.json
@@ -24,7 +24,7 @@
     "@babel/core": "^7.21.4",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/datasource-http/src/QueryEditor.tsx
+++ b/examples/datasource-http/src/QueryEditor.tsx
@@ -1,7 +1,7 @@
 import defaults from 'lodash/defaults';
 
 import React, { ChangeEvent, PureComponent } from 'react';
-import { LegacyForms } from '@grafana/ui';
+import { LegacyForms, HorizontalGroup } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from './DataSource';
 import { defaultQuery, MyDataSourceOptions, MyQuery } from './types';
@@ -28,7 +28,7 @@ export class QueryEditor extends PureComponent<Props> {
     const { queryText, constant } = query;
 
     return (
-      <div className="gf-form">
+      <HorizontalGroup>
         <FormField
           width={4}
           value={constant}
@@ -44,7 +44,7 @@ export class QueryEditor extends PureComponent<Props> {
           label="Query Text"
           tooltip="Not used yet"
         />
-      </div>
+      </HorizontalGroup>
     );
   }
 }

--- a/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/package.json
+++ b/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/package.json
@@ -23,7 +23,7 @@
     "@grafana/e2e-selectors": "10.0.3",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.62",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/src/components/ConfigEditor.tsx
+++ b/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/src/components/ConfigEditor.tsx
@@ -23,22 +23,20 @@ export function ConfigEditor(props: Props) {
   const { uri } = jsonData;
 
   return (
-    <div className="gf-form-group">
-      <FieldSet label="Connection">
-        <InlineFieldRow>
-          <InlineField label="URI" labelWidth={10} tooltip="Supported schemes: WebSocket (ws://) or (wss://)">
-            <Input
-              width={30}
-              name="uri"
-              required
-              value={uri}
-              autoComplete="off"
-              placeholder="ws://websocket-server:8080"
-              onChange={onUriChange}
-            />
-          </InlineField>
-        </InlineFieldRow>
-      </FieldSet>
-    </div>
+    <FieldSet label="Connection">
+      <InlineFieldRow>
+        <InlineField label="URI" labelWidth={10} tooltip="Supported schemes: WebSocket (ws://) or (wss://)">
+          <Input
+            width={30}
+            name="uri"
+            required
+            value={uri}
+            autoComplete="off"
+            placeholder="ws://websocket-server:8080"
+            onChange={onUriChange}
+          />
+        </InlineField>
+      </InlineFieldRow>
+    </FieldSet>
   );
 }

--- a/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/src/components/QueryEditor.tsx
+++ b/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/src/components/QueryEditor.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent } from 'react';
-import { InlineField, Input } from '@grafana/ui';
+import { InlineField, Input, HorizontalGroup } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from '../datasource';
 import { MyDataSourceOptions, MyQuery } from '../types';
@@ -18,13 +18,13 @@ export function QueryEditor({ query, onChange, onRunQuery }: Props) {
   const { upperLimit, lowerLimit } = query;
 
   return (
-    <div className="gf-form">
+    <HorizontalGroup>
       <InlineField label="Lower Limit" labelWidth={16} tooltip="Random numbers lower limit">
         <Input onChange={onLowerLimitChange} onBlur={onRunQuery} value={lowerLimit || ''} type="number" />
       </InlineField>
       <InlineField label="Upper Limit" labelWidth={16} tooltip="Random numbers upper limit">
         <Input onChange={onUpperLimitChange} onBlur={onRunQuery} value={upperLimit || ''} type="number" />
       </InlineField>
-    </div>
+    </HorizontalGroup>
   );
 }

--- a/examples/datasource-streaming-websocket/streaming-websocket-plugin/package.json
+++ b/examples/datasource-streaming-websocket/streaming-websocket-plugin/package.json
@@ -24,7 +24,7 @@
     "@babel/core": "^7.21.4",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/ConfigEditor.tsx
+++ b/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/ConfigEditor.tsx
@@ -24,17 +24,13 @@ export class ConfigEditor extends PureComponent<Props, State> {
     const { jsonData } = options;
 
     return (
-      <div className="gf-form-group">
-        <div className="gf-form">
-          <FormField
-            label="WebSocket server URL"
-            labelWidth={10}
-            inputWidth={20}
-            onChange={this.onURLChange}
-            value={jsonData.url || ''}
-          />
-        </div>
-      </div>
+      <FormField
+        label="WebSocket server URL"
+        labelWidth={10}
+        inputWidth={20}
+        onChange={this.onURLChange}
+        value={jsonData.url || ''}
+      />
     );
   }
 }

--- a/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/QueryEditor.tsx
+++ b/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/QueryEditor.tsx
@@ -1,5 +1,5 @@
 import { QueryEditorProps } from '@grafana/data';
-import { LegacyForms } from '@grafana/ui';
+import { LegacyForms, HorizontalGroup } from '@grafana/ui';
 import defaults from 'lodash/defaults';
 import React, { ChangeEvent, PureComponent } from 'react';
 import { DataSource } from './DataSource';
@@ -27,7 +27,7 @@ export class QueryEditor extends PureComponent<Props> {
     const { queryText, constant } = query;
 
     return (
-      <div className="gf-form">
+      <HorizontalGroup>
         <FormField
           width={4}
           value={constant}
@@ -43,7 +43,7 @@ export class QueryEditor extends PureComponent<Props> {
           label="Query Text"
           tooltip="Not used yet"
         />
-      </div>
+      </HorizontalGroup>
     );
   }
 }

--- a/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/plugin.json
+++ b/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
-  "name": "Example",
+  "name": "Streaming websocket example",
   "id": "example-websocket-datasource",
   "info": {
     "description": "",

--- a/examples/panel-basic/package.json
+++ b/examples/panel-basic/package.json
@@ -23,7 +23,7 @@
     "@grafana/e2e-selectors": "10.0.3",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/panel-datalinks/package.json
+++ b/examples/panel-datalinks/package.json
@@ -23,7 +23,7 @@
     "@grafana/e2e-selectors": "10.0.3",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/panel-flot/package.json
+++ b/examples/panel-flot/package.json
@@ -24,7 +24,7 @@
     "@babel/core": "^7.21.4",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/panel-frame-select/package.json
+++ b/examples/panel-frame-select/package.json
@@ -24,7 +24,7 @@
     "@babel/core": "^7.21.4",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/panel-plotly/package.json
+++ b/examples/panel-plotly/package.json
@@ -24,7 +24,7 @@
     "@babel/core": "^7.21.4",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/panel-scatterplot/package.json
+++ b/examples/panel-scatterplot/package.json
@@ -24,7 +24,7 @@
     "@babel/core": "^7.21.4",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/examples/panel-visx/package.json
+++ b/examples/panel-visx/package.json
@@ -24,7 +24,7 @@
     "@babel/core": "^7.21.4",
     "@grafana/eslint-config": "6.0.0",
     "@grafana/tsconfig": "1.3.0-rc1",
-    "@swc/core": "^1.3.51",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",


### PR DESCRIPTION
**What this PR does**

- Uses grafana/ui components in examples rather than referring to gf class names in the components

- Deletes unused gf class names in the components

- swc/core version was changed to 1.3.75, because of the bug 'base_dir(./src) must be absolute. Please ensure that `jsc.baseUrl` is specified correctly.'

**Which task does it solve**
#173 