### PR TITLE
chore: update links to dev portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ There is a github workflow `.github/workflows/integration-tests.yml` which finds
 
 ## Using the examples as the base for your plugins
 
-All of the examples use [grafana/create-plugin](https://grafana.github.io/plugin-tools/) instead of `@grafana/toolkit`.
+All of the examples use [grafana/create-plugin](https://grafana.com/developers/plugin-tools) instead of `@grafana/toolkit`.
 
-You can read more about customizing and extending the base configuration [here](https://grafana.github.io/plugin-tools/docs/advanced-configuration)
+You can read more about customizing and extending the base configuration [here](https://grafana.com/developers/plugin-tools/create-a-plugin/extend-a-plugin/extend-configurations)
 
 ## API Compatibility
 

--- a/examples/app-with-scenes/README.md
+++ b/examples/app-with-scenes/README.md
@@ -10,7 +10,7 @@ App plugins can let you create a custom out-of-the-box monitoring experience by 
 
 [@grafana/scenes](https://github.com/grafana/scenes) is a framework to enable versatile app plugins implementation. It provides an easy way to build apps that resemble Grafana's dashboarding experience, including template variables support, versatile layouts, panels rendering and more.
 
-To learn more about @grafana/scenes usage please refer to [documentation](https://grafana.github.io/scenes)
+To learn more about @grafana/scenes usage please refer to [documentation](https://grafana.com/developers/scenes)
 
 ## What does this template contain?
 


### PR DESCRIPTION
These appear to be the only references outside the scaffolded plugin files for which we'll need to follow up once the new version of create-plugin with https://github.com/grafana/plugin-tools/pull/382 is out

