### PR TITLE
Update examples to useTheme2

### DIFF
--- a/examples/panel-plotly/src/PlotlyPanel.tsx
+++ b/examples/panel-plotly/src/PlotlyPanel.tsx
@@ -1,5 +1,5 @@
-import { GrafanaTheme, PanelProps } from '@grafana/data';
-import { useTheme } from '@grafana/ui';
+import { GrafanaTheme2, PanelProps } from '@grafana/data';
+import { useTheme2 } from '@grafana/ui';
 import defaults from 'lodash/defaults';
 import React from 'react';
 import Plot from 'react-plotly.js';
@@ -8,7 +8,7 @@ import { PlotlyOptions } from 'types';
 interface Props extends PanelProps<PlotlyOptions> {}
 
 export const PlotlyPanel: React.FC<Props> = ({ options, data, width, height }) => {
-  const theme = useTheme();
+  const theme = useTheme2();
 
   const plotlyData: Plotly.Data[] = [
     {
@@ -33,7 +33,7 @@ export const PlotlyPanel: React.FC<Props> = ({ options, data, width, height }) =
 };
 
 // defaultLayout resets the Plotly layout to work better with the Grafana theme.
-const defaultLayout = (theme: GrafanaTheme) => ({
+const defaultLayout = (theme: GrafanaTheme2) => ({
   margin: {
     r: 40,
     l: 40,
@@ -43,6 +43,6 @@ const defaultLayout = (theme: GrafanaTheme) => ({
   plot_bgcolor: 'rgba(0,0,0,0)', // Transparent
   paper_bgcolor: 'rgba(0,0,0,0)', // Transparent
   font: {
-    color: theme.isDark ? theme.palette.white : theme.palette.black,
+    color: theme.visualization.getColorByName(theme.isDark ? 'white' : 'black'),
   },
 });

--- a/examples/panel-scatterplot/src/ScatterPanel.tsx
+++ b/examples/panel-scatterplot/src/ScatterPanel.tsx
@@ -1,5 +1,5 @@
 import { PanelProps } from '@grafana/data';
-import { useTheme } from '@grafana/ui';
+import { useTheme2 } from '@grafana/ui';
 import * as d3 from 'd3';
 import React from 'react';
 import { ScatterOptions } from 'types';
@@ -7,7 +7,7 @@ import { ScatterOptions } from 'types';
 interface Props extends PanelProps<ScatterOptions> {}
 
 export const ScatterPanel: React.FC<Props> = ({ options, data, width, height }) => {
-  const theme = useTheme();
+  const theme = useTheme2();
 
   const margin = { left: 30, top: 30, right: 30, bottom: 30 };
 
@@ -31,7 +31,13 @@ export const ScatterPanel: React.FC<Props> = ({ options, data, width, height }) 
       <g transform={`translate(${margin.left}, ${margin.top})`}>
         <g>
           {points.map((d: any, key: number) => (
-            <circle key={key} cx={xScale(d.x)} cy={yScale(d.y)} r={5} fill={theme.palette.greenBase}></circle>
+            <circle
+              key={key}
+              cx={xScale(d.x)}
+              cy={yScale(d.y)}
+              r={5}
+              fill={theme.visualization.getColorByName('green')}
+            ></circle>
           ))}
         </g>
         <g


### PR DESCRIPTION
Update examples that were using `useTheme` to `useTheme2`

Fixes https://github.com/grafana/grafana-plugin-examples/issues/195