### PR TITLE
Switch to secureJsonFields

### DIFF
--- a/examples/app-basic/provisioning/plugins/app.yaml
+++ b/examples/app-basic/provisioning/plugins/app.yaml
@@ -7,6 +7,5 @@ apps:
     disabled: false
     jsonData:
       apiUrl: http://default-url.com
-      isApiKeySet: true
     secureJsonData:
       apiKey: secret-key

--- a/examples/app-basic/src/components/AppConfig/AppConfig.tsx
+++ b/examples/app-basic/src/components/AppConfig/AppConfig.tsx
@@ -8,7 +8,6 @@ import { testIds } from '../testIds';
 
 export type JsonData = {
   apiUrl?: string;
-  isApiKeySet?: boolean;
 };
 
 type State = {
@@ -26,11 +25,11 @@ interface Props extends PluginConfigPageProps<AppPluginMeta<JsonData>> {}
 
 export const AppConfig = ({ plugin }: Props) => {
   const s = useStyles2(getStyles);
-  const { enabled, pinned, jsonData } = plugin.meta;
+  const { enabled, pinned, jsonData, secureJsonFields } = plugin.meta;
   const [state, setState] = useState<State>({
     apiUrl: jsonData?.apiUrl || '',
     apiKey: '',
-    isApiKeySet: Boolean(jsonData?.isApiKeySet),
+    isApiKeySet: Boolean(secureJsonFields?.apiKey),
   });
 
   const onResetApiKey = () =>
@@ -137,7 +136,6 @@ export const AppConfig = ({ plugin }: Props) => {
                 pinned,
                 jsonData: {
                   apiUrl: state.apiUrl,
-                  isApiKeySet: true,
                 },
                 // This cannot be queried later by the frontend.
                 // We don't want to override it in case it was set previously and left untouched now.

--- a/examples/app-with-backend/src/components/AppConfig/AppConfig.tsx
+++ b/examples/app-with-backend/src/components/AppConfig/AppConfig.tsx
@@ -8,7 +8,6 @@ import { testIds } from '../testIds';
 
 export type JsonData = {
   apiUrl?: string;
-  isApiKeySet?: boolean;
 };
 
 interface Props extends PluginConfigPageProps<AppPluginMeta<JsonData>> {}

--- a/examples/app-with-scenes/provisioning/plugins/app.yaml
+++ b/examples/app-with-scenes/provisioning/plugins/app.yaml
@@ -7,6 +7,5 @@ apps:
     disabled: false
     jsonData:
       apiUrl: http://default-url.com
-      isApiKeySet: true
     secureJsonData:
       apiKey: secret-key

--- a/examples/app-with-scenes/src/components/AppConfig/AppConfig.tsx
+++ b/examples/app-with-scenes/src/components/AppConfig/AppConfig.tsx
@@ -7,7 +7,6 @@ import { testIds } from '../testIds';
 
 export type JsonData = {
   apiUrl?: string;
-  isApiKeySet?: boolean;
 };
 
 type State = {
@@ -25,11 +24,11 @@ interface Props extends PluginConfigPageProps<AppPluginMeta<JsonData>> {}
 
 export const AppConfig = ({ plugin }: Props) => {
   const s = useStyles2(getStyles);
-  const { enabled, pinned, jsonData } = plugin.meta;
+  const { enabled, pinned, jsonData, secureJsonFields } = plugin.meta;
   const [state, setState] = useState<State>({
     apiUrl: jsonData?.apiUrl || '',
     apiKey: '',
-    isApiKeySet: Boolean(jsonData?.isApiKeySet),
+    isApiKeySet: Boolean(secureJsonFields?.apiKey),
   });
 
   const onResetApiKey = () =>
@@ -136,7 +135,6 @@ export const AppConfig = ({ plugin }: Props) => {
                 pinned,
                 jsonData: {
                   apiUrl: state.apiUrl,
-                  isApiKeySet: true,
                 },
                 // This cannot be queried later by the frontend.
                 // We don't want to override it in case it was set previously and left untouched now.


### PR DESCRIPTION
### What it this PR about?
Use `secureJsonFields` in our examples instead extra property in `secureJson`
Solves https://github.com/grafana/grafana-plugin-examples/issues/189

### Note for reviwers:
https://github.com/grafana/grafana-plugin-examples/issues/189 asks for changes specifically in `app-with-backend`, but this plugin is not really using the `secureJsonFields` for anything.

The issue also asks to use the code suggested in https://github.com/grafana/grafana/pull/55313, but to allow the form to behave correctly the state property is necessary, therefore only the initial state value is changed to be taken from `secureJsonFields`. Make the form dependent only on a property won't allow the required form control.