### PR TITLE
Update node version to 18

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup node version
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Install dependencies
         run: yarn install
       - name: Build plugin

--- a/examples/app-basic/package.json
+++ b/examples/app-basic/package.json
@@ -54,7 +54,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/app-with-backend/package.json
+++ b/examples/app-with-backend/package.json
@@ -57,7 +57,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/app-with-dashboards/.github/workflows/ci.yml
+++ b/examples/app-with-dashboards/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: '14.x'
+          node-version: '18.x'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/examples/app-with-dashboards/.github/workflows/is-compatible.yml
+++ b/examples/app-with-dashboards/.github/workflows/is-compatible.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install dependencies
         run: yarn install
       - name: Build plugin

--- a/examples/app-with-dashboards/.github/workflows/release.yml
+++ b/examples/app-with-dashboards/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: '14.x'
+          node-version: '18.x'
 
       - name: Setup Go environment
         uses: actions/setup-go@v4

--- a/examples/app-with-dashboards/package.json
+++ b/examples/app-with-dashboards/package.json
@@ -55,7 +55,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/app-with-extension-point/package.json
+++ b/examples/app-with-extension-point/package.json
@@ -55,7 +55,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/app-with-extensions/package.json
+++ b/examples/app-with-extensions/package.json
@@ -55,7 +55,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/app-with-on-behalf-of-auth/package.json
+++ b/examples/app-with-on-behalf-of-auth/package.json
@@ -54,7 +54,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/app-with-scenes/package.json
+++ b/examples/app-with-scenes/package.json
@@ -54,7 +54,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/datasource-basic/package.json
+++ b/examples/datasource-basic/package.json
@@ -56,7 +56,7 @@
     "rxjs": "7.3.0"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/datasource-http-backend/package.json
+++ b/examples/datasource-http-backend/package.json
@@ -54,7 +54,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/datasource-http/package.json
+++ b/examples/datasource-http/package.json
@@ -55,7 +55,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/package.json
+++ b/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/package.json
@@ -53,7 +53,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/datasource-streaming-websocket/streaming-websocket-plugin/package.json
+++ b/examples/datasource-streaming-websocket/streaming-websocket-plugin/package.json
@@ -55,7 +55,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/panel-basic/package.json
+++ b/examples/panel-basic/package.json
@@ -53,7 +53,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/panel-datalinks/package.json
+++ b/examples/panel-datalinks/package.json
@@ -53,7 +53,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/panel-flot/package.json
+++ b/examples/panel-flot/package.json
@@ -56,7 +56,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/panel-frame-select/package.json
+++ b/examples/panel-frame-select/package.json
@@ -55,7 +55,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/panel-plotly/package.json
+++ b/examples/panel-plotly/package.json
@@ -55,7 +55,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/panel-scatterplot/package.json
+++ b/examples/panel-scatterplot/package.json
@@ -56,7 +56,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",

--- a/examples/panel-visx/package.json
+++ b/examples/panel-visx/package.json
@@ -56,7 +56,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",


### PR DESCRIPTION
## What does this PR do?
Updates node version to 18
Closes https://github.com/grafana/grafana-plugin-examples/issues/199

## Note for reviewer
I've checked all the js files build using node 16 and compare it with the ones created by node 18. And everything was exactly the same.
I've used this script https://gist.github.com/oshirohugo/2f1a7de9f25487a74c4f3d939025722d

The integration tests in github are also passing (except datasource-basic) that will be fixed soon and it's related to an update in grafana https://github.com/grafana/grafana/pull/74795
