### PR TITLE
OnBehalfOf: Add Grafana configuration to the README

### DIFF
--- a/examples/app-with-on-behalf-of-auth/README.md
+++ b/examples/app-with-on-behalf-of-auth/README.md
@@ -2,13 +2,26 @@
 
 This plugin is an example of how to integrate OAuth2 authentication into a Grafana plugin.
 
-**Note:** This plugin requires Grafana 10.1 or later and the `externalServiceAuth` feature toggle must be enabled. This is an experimental feature.
+**Note:** This plugin requires Grafana 10.1 or later
 
 ## How to use
 
 This app allows you to do requests to the Grafana API as the plugin or on behalf of a user (by specifying the user ID). The plugin will then use the access token to do requests to the Grafana API.
 
 ![screenshot](./src/img/screenshot-showcase.png)
+
+## Grafana configuration
+
+This is an experimental feature, the `externalServiceAuth` feature toggle must be enabled. 
+
+Additionally, Grafana needs `auth.extended_jwt` to be enabled and configured. Set your audience and issuer to your base URL. Example:
+
+```ini
+[auth.extended_jwt]
+enabled = true
+expect_audience = http://localhost:3000/
+expect_issuer = http://localhost:3000/
+```
 
 ## Authentication flow
 


### PR DESCRIPTION
This PR adds a "Grafana configuration" section to the README of the `app-with-on-behalf-of-auth` plugin example