### PR TITLE
App-With-On-Behalf-Of: Inject `extended_jwt` conf in grafana ini file

### DIFF
--- a/examples/app-with-on-behalf-of-auth/.config/Dockerfile
+++ b/examples/app-with-on-behalf-of-auth/.config/Dockerfile
@@ -14,3 +14,7 @@ ENV GF_DEFAULT_APP_MODE "development"
 # Inject livereload script into grafana index.html
 USER root
 RUN sed -i 's/<\/body><\/html>/<script src=\"http:\/\/localhost:35729\/livereload.js\"><\/script><\/body><\/html>/g' /usr/share/grafana/public/views/index.html
+
+# Inject [extended_jwt] config in ini file
+COPY extended_jwt.ini /tmp/extended_jwt.ini
+RUN cat /tmp/extended_jwt.ini >> /etc/grafana/grafana.ini

--- a/examples/app-with-on-behalf-of-auth/.config/extended_jwt.ini
+++ b/examples/app-with-on-behalf-of-auth/.config/extended_jwt.ini
@@ -1,0 +1,5 @@
+
+[auth.extended_jwt]
+enabled = true
+expect_audience = http://localhost:3000/
+expect_issuer = http://localhost:3000/


### PR DESCRIPTION
The `extended_jwt` config options are not overridable with env variables.
  
There were multiple ways of tackling this:
* changing Grafana to enable env overrides
* mounting a `custom.ini` file and using it instead of `/etc/grafana/grafana.ini`
* appending the `extended_jwt` config to the `/etc/grafana/grafana.ini`

I chose the last option so that it works with `grafana:main` already but also because we won't need to update the `custom.ini` file with grafana version increases.

Challenges are welcome.