### PR TITLE
Logs data source: deprecate showContextToggle

### DIFF
--- a/examples/datasource-logs/package-lock.json
+++ b/examples/datasource-logs/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",
-        "@grafana/data": "10.2.0",
+        "@grafana/data": "10.3.0",
         "@grafana/runtime": "10.1.0",
         "@grafana/ui": "10.1.0",
         "loadash": "^1.0.0",
@@ -2123,12 +2123,13 @@
       }
     },
     "node_modules/@grafana/data": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-10.2.0.tgz",
-      "integrity": "sha512-MPUmkokQY7AWbJKVundp9AtTZdk4HqZHUCNvM1TFkTACUW9rVCi5fmmjwJQFLfTJ9JL2fkls8Z6S1l9Hd9ViTw==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-10.3.0.tgz",
+      "integrity": "sha512-jyAjk4qtJWD1ruXz4BkgVPAvQziNIuiNvLOu0u7ddMsBzmbLLt3kTSFwfEN4HYEJo/VEP+2DaVErfQ6GwL2tGA==",
+      "deprecated": "This version was published by accident and does NOT contain the code of Grafana 10.3.0.",
       "dependencies": {
         "@braintree/sanitize-url": "6.0.2",
-        "@grafana/schema": "10.2.0",
+        "@grafana/schema": "10.3.0",
         "@types/d3-interpolate": "^3.0.0",
         "@types/string-hash": "1.1.1",
         "d3-interpolate": "3.0.1",
@@ -2159,9 +2160,10 @@
       }
     },
     "node_modules/@grafana/data/node_modules/@grafana/schema": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-10.2.0.tgz",
-      "integrity": "sha512-IvjlezsOfIRjnsOwTJ1qu1GWbq9Rz3ofFi2Pd+1Brza6Gn951Hv/5MlLwqIuZJ+VnSVs35ZlNOl3sz9uSq2ibg==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-10.3.0.tgz",
+      "integrity": "sha512-dbNC3gfj/zRw3lVPr/TffKZLmmGzW38EHMXunMatKv1nc5A+BscRwH9xHO2LDrsHzkGEdW8ROwVYAkIWbxl/0Q==",
+      "deprecated": "This version was published by accident and does NOT contain the code of Grafana 10.3.0.",
       "dependencies": {
         "tslib": "2.6.0"
       }

--- a/examples/datasource-logs/package-lock.json
+++ b/examples/datasource-logs/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",
-        "@grafana/data": "10.1.0",
+        "@grafana/data": "10.2.0",
         "@grafana/runtime": "10.1.0",
         "@grafana/ui": "10.1.0",
         "loadash": "^1.0.0",
@@ -2123,34 +2123,34 @@
       }
     },
     "node_modules/@grafana/data": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-10.1.0.tgz",
-      "integrity": "sha512-PzjeXSJJP14p4mSvL/+7+iDFVWQcU/T8deB5ppZG5efZS20fnWoiLL+JZOvjSMtXlPcsroJ2Rr4ygUciu7R+4g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-10.2.0.tgz",
+      "integrity": "sha512-MPUmkokQY7AWbJKVundp9AtTZdk4HqZHUCNvM1TFkTACUW9rVCi5fmmjwJQFLfTJ9JL2fkls8Z6S1l9Hd9ViTw==",
       "dependencies": {
         "@braintree/sanitize-url": "6.0.2",
-        "@grafana/schema": "10.1.0",
+        "@grafana/schema": "10.2.0",
         "@types/d3-interpolate": "^3.0.0",
         "@types/string-hash": "1.1.1",
         "d3-interpolate": "3.0.1",
         "date-fns": "2.30.0",
         "dompurify": "^2.4.3",
-        "eventemitter3": "5.0.0",
+        "eventemitter3": "5.0.1",
         "fast_array_intersect": "1.1.0",
         "history": "4.10.1",
         "lodash": "4.17.21",
         "marked": "5.1.1",
         "marked-mangle": "1.1.0",
         "moment": "2.29.4",
-        "moment-timezone": "0.5.41",
+        "moment-timezone": "0.5.43",
         "ol": "7.4.0",
         "papaparse": "5.4.1",
         "react-use": "17.4.0",
         "regenerator-runtime": "0.13.11",
-        "rxjs": "7.8.0",
+        "rxjs": "7.8.1",
         "string-hash": "^1.1.3",
         "tinycolor2": "1.6.0",
         "tslib": "2.6.0",
-        "uplot": "1.6.24",
+        "uplot": "1.6.26",
         "xss": "^1.0.14"
       },
       "peerDependencies": {
@@ -2158,10 +2158,18 @@
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@grafana/data/node_modules/@grafana/schema": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-10.2.0.tgz",
+      "integrity": "sha512-IvjlezsOfIRjnsOwTJ1qu1GWbq9Rz3ofFi2Pd+1Brza6Gn951Hv/5MlLwqIuZJ+VnSVs35ZlNOl3sz9uSq2ibg==",
+      "dependencies": {
+        "tslib": "2.6.0"
+      }
+    },
     "node_modules/@grafana/data/node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -2170,6 +2178,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
       "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+    },
+    "node_modules/@grafana/data/node_modules/uplot": {
+      "version": "1.6.26",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.26.tgz",
+      "integrity": "sha512-qN0mveL6UsP40TnHzHAJkUQvpfA3y8zSLXtXKVlJo/sLfj2+vjan/Z3g81MCZjy/hEDUFNtnLftPmETDA4s7Rg=="
     },
     "node_modules/@grafana/e2e": {
       "version": "9.5.3",
@@ -2720,6 +2733,42 @@
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@grafana/runtime/node_modules/@grafana/data": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-10.1.0.tgz",
+      "integrity": "sha512-PzjeXSJJP14p4mSvL/+7+iDFVWQcU/T8deB5ppZG5efZS20fnWoiLL+JZOvjSMtXlPcsroJ2Rr4ygUciu7R+4g==",
+      "dependencies": {
+        "@braintree/sanitize-url": "6.0.2",
+        "@grafana/schema": "10.1.0",
+        "@types/d3-interpolate": "^3.0.0",
+        "@types/string-hash": "1.1.1",
+        "d3-interpolate": "3.0.1",
+        "date-fns": "2.30.0",
+        "dompurify": "^2.4.3",
+        "eventemitter3": "5.0.0",
+        "fast_array_intersect": "1.1.0",
+        "history": "4.10.1",
+        "lodash": "4.17.21",
+        "marked": "5.1.1",
+        "marked-mangle": "1.1.0",
+        "moment": "2.29.4",
+        "moment-timezone": "0.5.41",
+        "ol": "7.4.0",
+        "papaparse": "5.4.1",
+        "react-use": "17.4.0",
+        "regenerator-runtime": "0.13.11",
+        "rxjs": "7.8.0",
+        "string-hash": "^1.1.3",
+        "tinycolor2": "1.6.0",
+        "tslib": "2.6.0",
+        "uplot": "1.6.24",
+        "xss": "^1.0.14"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@grafana/runtime/node_modules/@grafana/e2e-selectors": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-10.1.0.tgz",
@@ -2728,6 +2777,22 @@
         "@grafana/tsconfig": "^1.2.0-rc1",
         "tslib": "2.6.0",
         "typescript": "4.8.4"
+      }
+    },
+    "node_modules/@grafana/runtime/node_modules/eventemitter3": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.0.tgz",
+      "integrity": "sha512-riuVbElZZNXLeLEoprfNYoDSwTBRR44X3mnhdI1YcnENpWTCsTTVZ2zFuqQcpoyqPQIUXdiPEU0ECAq0KQRaHg=="
+    },
+    "node_modules/@grafana/runtime/node_modules/moment-timezone": {
+      "version": "0.5.41",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.41.tgz",
+      "integrity": "sha512-e0jGNZDOHfBXJGz8vR/sIMXvBIGJJcqFjmlg9lmE+5KX1U7/RZNMswfD8nKnNCnQdKTIj50IaRKwl1fvMLyyRg==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@grafana/runtime/node_modules/rxjs": {
@@ -2838,6 +2903,42 @@
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@grafana/ui/node_modules/@grafana/data": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-10.1.0.tgz",
+      "integrity": "sha512-PzjeXSJJP14p4mSvL/+7+iDFVWQcU/T8deB5ppZG5efZS20fnWoiLL+JZOvjSMtXlPcsroJ2Rr4ygUciu7R+4g==",
+      "dependencies": {
+        "@braintree/sanitize-url": "6.0.2",
+        "@grafana/schema": "10.1.0",
+        "@types/d3-interpolate": "^3.0.0",
+        "@types/string-hash": "1.1.1",
+        "d3-interpolate": "3.0.1",
+        "date-fns": "2.30.0",
+        "dompurify": "^2.4.3",
+        "eventemitter3": "5.0.0",
+        "fast_array_intersect": "1.1.0",
+        "history": "4.10.1",
+        "lodash": "4.17.21",
+        "marked": "5.1.1",
+        "marked-mangle": "1.1.0",
+        "moment": "2.29.4",
+        "moment-timezone": "0.5.41",
+        "ol": "7.4.0",
+        "papaparse": "5.4.1",
+        "react-use": "17.4.0",
+        "regenerator-runtime": "0.13.11",
+        "rxjs": "7.8.0",
+        "string-hash": "^1.1.3",
+        "tinycolor2": "1.6.0",
+        "tslib": "2.6.0",
+        "uplot": "1.6.24",
+        "xss": "^1.0.14"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@grafana/ui/node_modules/@grafana/e2e-selectors": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-10.1.0.tgz",
@@ -2846,6 +2947,22 @@
         "@grafana/tsconfig": "^1.2.0-rc1",
         "tslib": "2.6.0",
         "typescript": "4.8.4"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/eventemitter3": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.0.tgz",
+      "integrity": "sha512-riuVbElZZNXLeLEoprfNYoDSwTBRR44X3mnhdI1YcnENpWTCsTTVZ2zFuqQcpoyqPQIUXdiPEU0ECAq0KQRaHg=="
+    },
+    "node_modules/@grafana/ui/node_modules/moment-timezone": {
+      "version": "0.5.41",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.41.tgz",
+      "integrity": "sha512-e0jGNZDOHfBXJGz8vR/sIMXvBIGJJcqFjmlg9lmE+5KX1U7/RZNMswfD8nKnNCnQdKTIj50IaRKwl1fvMLyyRg==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@grafana/ui/node_modules/rxjs": {
@@ -9810,9 +9927,9 @@
       "dev": true
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.0.tgz",
-      "integrity": "sha512-riuVbElZZNXLeLEoprfNYoDSwTBRR44X3mnhdI1YcnENpWTCsTTVZ2zFuqQcpoyqPQIUXdiPEU0ECAq0KQRaHg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -15883,9 +16000,9 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.41",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.41.tgz",
-      "integrity": "sha512-e0jGNZDOHfBXJGz8vR/sIMXvBIGJJcqFjmlg9lmE+5KX1U7/RZNMswfD8nKnNCnQdKTIj50IaRKwl1fvMLyyRg==",
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
       "dependencies": {
         "moment": "^2.29.4"
       },

--- a/examples/datasource-logs/package-lock.json
+++ b/examples/datasource-logs/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",
-        "@grafana/data": "10.3.0",
+        "@grafana/data": "10.3.3",
         "@grafana/runtime": "10.1.0",
         "@grafana/ui": "10.1.0",
         "loadash": "^1.0.0",
@@ -2123,13 +2123,12 @@
       }
     },
     "node_modules/@grafana/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-jyAjk4qtJWD1ruXz4BkgVPAvQziNIuiNvLOu0u7ddMsBzmbLLt3kTSFwfEN4HYEJo/VEP+2DaVErfQ6GwL2tGA==",
-      "deprecated": "This version was published by accident and does NOT contain the code of Grafana 10.3.0.",
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-10.3.3.tgz",
+      "integrity": "sha512-TkTxe/gHvLenTayDjqfM70kqRO18RyAyHCRlCGOlLOQF1J3YRqSvEnr91Izo1AmKOsWHr8IogXAEV1OjcNOmVg==",
       "dependencies": {
         "@braintree/sanitize-url": "6.0.2",
-        "@grafana/schema": "10.3.0",
+        "@grafana/schema": "10.3.3",
         "@types/d3-interpolate": "^3.0.0",
         "@types/string-hash": "1.1.1",
         "d3-interpolate": "3.0.1",
@@ -2146,12 +2145,12 @@
         "ol": "7.4.0",
         "papaparse": "5.4.1",
         "react-use": "17.4.0",
-        "regenerator-runtime": "0.13.11",
+        "regenerator-runtime": "0.14.0",
         "rxjs": "7.8.1",
         "string-hash": "^1.1.3",
         "tinycolor2": "1.6.0",
         "tslib": "2.6.0",
-        "uplot": "1.6.26",
+        "uplot": "1.6.28",
         "xss": "^1.0.14"
       },
       "peerDependencies": {
@@ -2160,13 +2159,17 @@
       }
     },
     "node_modules/@grafana/data/node_modules/@grafana/schema": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-10.3.0.tgz",
-      "integrity": "sha512-dbNC3gfj/zRw3lVPr/TffKZLmmGzW38EHMXunMatKv1nc5A+BscRwH9xHO2LDrsHzkGEdW8ROwVYAkIWbxl/0Q==",
-      "deprecated": "This version was published by accident and does NOT contain the code of Grafana 10.3.0.",
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-10.3.3.tgz",
+      "integrity": "sha512-u5jIBZe6lLsGoFmERJZ35+NTP72gJYYKgUKdiO48l78uSFAmPFgR/t2MeNlY5wJTRgi54GB7giMwzrXnM4qlFg==",
       "dependencies": {
         "tslib": "2.6.0"
       }
+    },
+    "node_modules/@grafana/data/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@grafana/data/node_modules/rxjs": {
       "version": "7.8.1",
@@ -2182,9 +2185,9 @@
       "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/@grafana/data/node_modules/uplot": {
-      "version": "1.6.26",
-      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.26.tgz",
-      "integrity": "sha512-qN0mveL6UsP40TnHzHAJkUQvpfA3y8zSLXtXKVlJo/sLfj2+vjan/Z3g81MCZjy/hEDUFNtnLftPmETDA4s7Rg=="
+      "version": "1.6.28",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.28.tgz",
+      "integrity": "sha512-6AQ/Hu2ZvwF1P6PtIELdWKFml8Vvf3PUqrkVndL4A1+s/0loHwXfsk3yMwy4WGkRAt0MAMpf0uKLa9h0Yt3miw=="
     },
     "node_modules/@grafana/e2e": {
       "version": "9.5.3",

--- a/examples/datasource-logs/package.json
+++ b/examples/datasource-logs/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",
-    "@grafana/data": "10.1.0",
+    "@grafana/data": "10.2.0",
     "@grafana/runtime": "10.1.0",
     "@grafana/ui": "10.1.0",
     "loadash": "^1.0.0",

--- a/examples/datasource-logs/package.json
+++ b/examples/datasource-logs/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",
-    "@grafana/data": "10.2.0",
+    "@grafana/data": "10.3.0",
     "@grafana/runtime": "10.1.0",
     "@grafana/ui": "10.1.0",
     "loadash": "^1.0.0",

--- a/examples/datasource-logs/package.json
+++ b/examples/datasource-logs/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",
-    "@grafana/data": "10.3.0",
+    "@grafana/data": "10.3.3",
     "@grafana/runtime": "10.1.0",
     "@grafana/ui": "10.1.0",
     "loadash": "^1.0.0",

--- a/examples/datasource-logs/src/datasource.ts
+++ b/examples/datasource-logs/src/datasource.ts
@@ -97,12 +97,6 @@ export class MyDataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> im
     return {...query, queryText};
   }
 
-  // This method can be used to show "context" button based on runtime conditions (for example, row model data or plugin settings)
-  showContextToggle() {
-    // If you want to always show toggle, you can just return true
-    return true
-  }
-
   async getLogRowContextQuery(
     row: LogRowModel,
     options?: LogRowContextOptions,


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/pull/77232, where we're deprecating the `showContextToggle` function.

**Which issue(s) this PR fixes**:

Related to https://github.com/grafana/grafana/issues/66819