### PR TITLE
Add filterQuery examples

### DIFF
--- a/examples/datasource-basic/src/datasource.ts
+++ b/examples/datasource-basic/src/datasource.ts
@@ -14,6 +14,13 @@ export class BasicDataSource extends DataSourceWithBackend<BasicQuery, BasicData
     };
   }
 
+  filterQuery(query: BasicQuery): boolean {
+    if (query.hide || query.rawQuery === '') {
+      return false;
+    }
+    return true;
+  }
+
   getAvailableQueryTypes(): Promise<QueryTypesResponse> {
     return this.getResource('/query-types');
   }

--- a/examples/datasource-http-backend/src/datasource.ts
+++ b/examples/datasource-http-backend/src/datasource.ts
@@ -11,4 +11,11 @@ export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptio
   getDefaultQuery(app: CoreApp): Partial<MyQuery> {
     return { multiplier: 1 };
   }
+
+  filterQuery(query: MyQuery): boolean {
+    if (query.hide) {
+      return false;
+    }
+    return true;
+  }
 }

--- a/examples/datasource-http/src/DataSource.ts
+++ b/examples/datasource-http/src/DataSource.ts
@@ -78,6 +78,13 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
     return lastValueFrom(response);
   }
 
+  filterQuery(query: MyQuery): boolean {
+    if (query.hide) {
+      return false;
+    }
+    return true;
+  }
+
   /**
    * Checks whether we can connect to the API.
    */

--- a/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/src/datasource.ts
+++ b/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/src/datasource.ts
@@ -39,4 +39,11 @@ export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptio
   getDefaultQuery(app: CoreApp): Partial<MyQuery> {
     return DEFAULT_QUERY;
   }
+
+  filterQuery(query: MyQuery): boolean {
+    if (query.hide) {
+      return false;
+    }
+    return true;
+  }
 }

--- a/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/DataSource.ts
+++ b/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/DataSource.ts
@@ -63,4 +63,11 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
       message: 'Success',
     };
   }
+
+  filterQuery(query: MyQuery): boolean {
+    if (query.hide) {
+      return false;
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
Add examples of how to filter out queries that are hidden or empty, which is something we recommend.