### PR TITLE
Fix: Datasource-Basic typings for 10.4.x canary

### DIFF
--- a/examples/datasource-basic/src/datasource.ts
+++ b/examples/datasource-basic/src/datasource.ts
@@ -7,7 +7,7 @@ export class BasicDataSource extends DataSourceWithBackend<BasicQuery, BasicData
     super(instanceSettings);
   }
 
-  applyTemplateVariables(query: BasicQuery, scopedVars: ScopedVars): Record<string, any> {
+  applyTemplateVariables(query: BasicQuery, scopedVars: ScopedVars) {
     return {
       ...query,
       rawQuery: getTemplateSrv().replace(query.rawQuery, scopedVars),


### PR DESCRIPTION
[This PR change in core grafana](https://github.com/grafana/grafana/pull/80464/files#diff-e66e8da9f7917f6cdf1356835e841715a074f285034ed29f6a5c7d1852fa97f7) has caused our builds to fail for the past few days.

This PR removes the explicit typings so typescript can implicitly understand them across current and 10.4.x releases.