### PR TITLE
Update query filtering examples 

### DIFF
--- a/examples/datasource-basic/src/datasource.ts
+++ b/examples/datasource-basic/src/datasource.ts
@@ -15,10 +15,7 @@ export class BasicDataSource extends DataSourceWithBackend<BasicQuery, BasicData
   }
 
   filterQuery(query: BasicQuery): boolean {
-    if (query.hide || query.rawQuery === '') {
-      return false;
-    }
-    return true;
+    return !!query.rawQuery;
   }
 
   getAvailableQueryTypes(): Promise<QueryTypesResponse> {

--- a/examples/datasource-http-backend/src/datasource.ts
+++ b/examples/datasource-http-backend/src/datasource.ts
@@ -8,14 +8,7 @@ export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptio
     super(instanceSettings);
   }
 
-  getDefaultQuery(app: CoreApp): Partial<MyQuery> {
+  getDefaultQuery(_: CoreApp): Partial<MyQuery> {
     return { multiplier: 1 };
-  }
-
-  filterQuery(query: MyQuery): boolean {
-    if (query.hide) {
-      return false;
-    }
-    return true;
   }
 }

--- a/examples/datasource-logs/src/datasource.ts
+++ b/examples/datasource-logs/src/datasource.ts
@@ -20,14 +20,20 @@ import {
 } from '@grafana/data';
 
 import { MyQuery, MyDataSourceOptions, DEFAULT_QUERY } from './types';
-import { fetchLogs, Log } from './mockDataRequest'
+import { fetchLogs, Log } from './mockDataRequest';
 import { catchError, forkJoin, from, interval, lastValueFrom } from 'rxjs';
-import { map, mergeMap } from 'rxjs/operators'
-import { defaults } from 'lodash';
+import { map, mergeMap } from 'rxjs/operators';
 
-export class MyDataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> implements DataSourceWithLogsContextSupport<MyQuery> {
+export class MyDataSource
+  extends DataSourceApi<MyQuery, MyDataSourceOptions>
+  implements DataSourceWithLogsContextSupport<MyQuery>
+{
   constructor(instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions>) {
     super(instanceSettings);
+  }
+
+  getDefaultQuery(_: CoreApp): Partial<MyQuery> {
+    return DEFAULT_QUERY;
   }
 
   query(request: DataQueryRequest<MyQuery>): any {
@@ -36,45 +42,45 @@ export class MyDataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> im
     // Process live streaming request
     if (liveStreaming) {
       // To simplify this, we only support one target in live streaming mode
-      const target = targets[0]
-      const query = defaults(target, DEFAULT_QUERY);
+      const query = targets[0];
       return interval(1000).pipe(
         mergeMap((i) => {
-          const addedTime = i * 10000
-          return from(fetchLogs(query.limit, range!.from.valueOf() + addedTime, range!.to.valueOf() + addedTime, query.queryText)).pipe(
+          const addedTime = i * 10000;
+          return from(
+            fetchLogs(query.limit, range!.from.valueOf() + addedTime, range!.to.valueOf() + addedTime, query.queryText)
+          ).pipe(
             map((logs: Log[]) => {
-              return {data: [this.processLogsToDataFrames(logs, query)], state: LoadingState.Streaming}
+              return { data: [this.processLogsToDataFrames(logs, query)], state: LoadingState.Streaming };
             })
-          )
-        }),
-      )
+          );
+        })
+      );
     }
 
     // Process regular log request
-    const fetchLogsObservables = targets.map((target) => {
-      const query = defaults(target, DEFAULT_QUERY);
+    const fetchLogsObservables = targets.map((query) => {
       return from(fetchLogs(query.limit, range!.from.valueOf(), range!.to.valueOf(), query.queryText)).pipe(
         map((logs: Log[]) => {
-          return {data: [this.processLogsToDataFrames(logs, query)], state: LoadingState.Done}
+          return { data: [this.processLogsToDataFrames(logs, query)], state: LoadingState.Done };
         })
-      )
-    })
+      );
+    });
 
     if (fetchLogsObservables.length === 1) {
-      return fetchLogsObservables[0]
+      return fetchLogsObservables[0];
     }
 
     return forkJoin(fetchLogsObservables).pipe(
       map((results: DataQueryResponse[]) => {
-          const data: DataFrame[] = [];
-          for (const result of results) {
-            for (const frame of result.data) {
-              data.push(frame);
-            }
+        const data: DataFrame[] = [];
+        for (const result of results) {
+          for (const frame of result.data) {
+            data.push(frame);
           }
-          return { state: LoadingState.Done, data }
-        })
-    )
+        }
+        return { state: LoadingState.Done, data };
+      })
+    );
   }
 
   // With modifyQuery, users can use log details to adjust the query
@@ -83,32 +89,28 @@ export class MyDataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> im
     switch (action.type) {
       case 'ADD_FILTER':
         if (action.options?.key && action.options?.value) {
-          queryText = `${queryText} ${action.options?.key}=${action.options.value}`
+          queryText = `${queryText} ${action.options?.key}=${action.options.value}`;
         }
         break;
       case 'ADD_FILTER_OUT':
         {
           if (action.options?.key && action.options?.value) {
-            queryText = `${queryText} ${action.options?.key}!=${action.options.value}`
+            queryText = `${queryText} ${action.options?.key}!=${action.options.value}`;
           }
         }
         break;
     }
-    return {...query, queryText};
+    return { ...query, queryText };
   }
 
-  async getLogRowContextQuery(
-    row: LogRowModel,
-    options?: LogRowContextOptions,
-    query?: MyQuery
-  ) {
+  async getLogRowContextQuery(row: LogRowModel, options?: LogRowContextOptions, query?: MyQuery) {
     if (query) {
       // Create a new query for the log context
-      const contextQuery = {...query, queryText: `${query.queryText} log-context + ${row.uid}`}
-      return Promise.resolve(contextQuery)
+      const contextQuery = { ...query, queryText: `${query.queryText} log-context + ${row.uid}` };
+      return Promise.resolve(contextQuery);
     }
 
-    return Promise.resolve(null)
+    return Promise.resolve(null);
   }
 
   async getLogRowContext(
@@ -116,32 +118,38 @@ export class MyDataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> im
     options?: LogRowContextOptions,
     query?: MyQuery
   ): Promise<DataQueryResponse> {
-    const lookBack = 6 * 60 * 60 * 1000 // 6 hours
+    const lookBack = 6 * 60 * 60 * 1000; // 6 hours
     const timeRange = {
-      from: options?.direction === LogRowContextQueryDirection.Forward ? dateTime(row.timeEpochMs - lookBack) : dateTime(row.timeEpochMs),
-      to: options?.direction === LogRowContextQueryDirection.Forward ? dateTime(row.timeEpochMs) :  dateTime(row.timeEpochMs + lookBack)
-    }
+      from:
+        options?.direction === LogRowContextQueryDirection.Forward
+          ? dateTime(row.timeEpochMs - lookBack)
+          : dateTime(row.timeEpochMs),
+      to:
+        options?.direction === LogRowContextQueryDirection.Forward
+          ? dateTime(row.timeEpochMs)
+          : dateTime(row.timeEpochMs + lookBack),
+    };
 
-    const contextQuery = await this.getLogRowContextQuery(row, options, query)
+    const contextQuery = await this.getLogRowContextQuery(row, options, query);
 
     const range = {
       ...timeRange,
-      raw: timeRange
-    }
-    
+      raw: timeRange,
+    };
+
     const intervalInfo = rangeUtil.calculateInterval(range, 1);
     const request = {
-    targets: contextQuery ? [contextQuery] : [],
-    requestId: `context-${query?.refId}`,
-    interval: intervalInfo.interval,
-    intervalMs: intervalInfo.intervalMs,
-    range,
-    scopedVars: {},
-    timezone: 'UTC',
-    app: CoreApp.Explore,
-    startTime: Date.now(),
-    hideFromInspector: true,
-  }
+      targets: contextQuery ? [contextQuery] : [],
+      requestId: `context-${query?.refId}`,
+      interval: intervalInfo.interval,
+      intervalMs: intervalInfo.intervalMs,
+      range,
+      scopedVars: {},
+      timezone: 'UTC',
+      app: CoreApp.Explore,
+      startTime: Date.now(),
+      hideFromInspector: true,
+    };
 
     // Execute log context query
     return lastValueFrom(
@@ -153,7 +161,7 @@ export class MyDataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> im
             statusText: err.statusText,
           };
           throw error;
-        }),
+        })
       )
     );
   }
@@ -166,40 +174,40 @@ export class MyDataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> im
     };
   }
 
-    private processLogsToDataFrames(logs: Log[], target: MyQuery) {
-    const timeStampValues: number[] = []
-    const bodyValues: string[] = []
-    const severityValues: string[] = []
-    const idValues: string[] = []
-    const labelsValues: object[] = []
+  private processLogsToDataFrames(logs: Log[], target: MyQuery) {
+    const timeStampValues: number[] = [];
+    const bodyValues: string[] = [];
+    const severityValues: string[] = [];
+    const idValues: string[] = [];
+    const labelsValues: object[] = [];
     logs.forEach((log) => {
-      const {timestamp, body, severity, id, ...rest} = log
-      timeStampValues.push(timestamp)
-      bodyValues.push(body)
-      severityValues.push(severity)
-      idValues.push(id)
-      labelsValues.push(rest)
-    })
-    
+      const { timestamp, body, severity, id, ...rest } = log;
+      timeStampValues.push(timestamp);
+      bodyValues.push(body);
+      severityValues.push(severity);
+      idValues.push(id);
+      labelsValues.push(rest);
+    });
+
     const dataFrame = createDataFrame({
       refId: target.refId,
-        fields: [
-          { name: 'timestamp', type: FieldType.time, values:  timeStampValues },
-          { name: 'body', type: FieldType.string, values: bodyValues },
-          { name: 'severity', type: FieldType.string, values: severityValues },
-          { name: 'id', type: FieldType.string, values: idValues },
-          { name: 'labels', type: FieldType.other, values:  labelsValues},
+      fields: [
+        { name: 'timestamp', type: FieldType.time, values: timeStampValues },
+        { name: 'body', type: FieldType.string, values: bodyValues },
+        { name: 'severity', type: FieldType.string, values: severityValues },
+        { name: 'id', type: FieldType.string, values: idValues },
+        { name: 'labels', type: FieldType.other, values: labelsValues },
       ],
       meta: {
-        type: DataFrameType.LogLines, 
+        type: DataFrameType.LogLines,
         preferredVisualisationType: 'logs',
         custom: {
           limit: target.limit,
           //error: "test error message",
-          searchWords: [target.queryText]
-        }
-      }
+          searchWords: [target.queryText],
+        },
+      },
     });
-    return dataFrame
+    return dataFrame;
   }
 }

--- a/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/src/datasource.ts
+++ b/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/src/datasource.ts
@@ -7,7 +7,6 @@ import {
 } from '@grafana/data';
 import { DataSourceWithBackend, getGrafanaLiveSrv } from '@grafana/runtime';
 
-import { defaults } from 'lodash';
 import { Observable, merge } from 'rxjs';
 
 import { MyQuery, MyDataSourceOptions, DEFAULT_QUERY } from './types';
@@ -18,9 +17,7 @@ export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptio
   }
 
   query(request: DataQueryRequest<MyQuery>): Observable<DataQueryResponse> {
-    const observables = request.targets.map((target, index) => {
-      const query = defaults(target, DEFAULT_QUERY);
-
+    const observables = request.targets.map((query) => {
       return getGrafanaLiveSrv().getDataStream({
         addr: {
           scope: LiveChannelScope.DataSource,
@@ -36,14 +33,7 @@ export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptio
     return merge(...observables);
   }
 
-  getDefaultQuery(app: CoreApp): Partial<MyQuery> {
+  getDefaultQuery(_: CoreApp): Partial<MyQuery> {
     return DEFAULT_QUERY;
-  }
-
-  filterQuery(query: MyQuery): boolean {
-    if (query.hide) {
-      return false;
-    }
-    return true;
   }
 }

--- a/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/DataSource.ts
+++ b/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/DataSource.ts
@@ -1,5 +1,6 @@
 import {
   CircularDataFrame,
+  CoreApp,
   DataQueryRequest,
   DataQueryResponse,
   DataSourceApi,
@@ -7,7 +8,6 @@ import {
   FieldType,
   LoadingState,
 } from '@grafana/data';
-import defaults from 'lodash/defaults';
 import { merge, Observable } from 'rxjs';
 import { defaultQuery, MyDataSourceOptions, MyQuery } from './types';
 
@@ -20,10 +20,12 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
     this.serverURL = instanceSettings.jsonData.url || 'ws://localhost:8080';
   }
 
-  query(options: DataQueryRequest<MyQuery>): Observable<DataQueryResponse> {
-    const observables = options.targets.map((target) => {
-      const query = defaults(target, defaultQuery);
+  getDefaultQuery(app: CoreApp): Partial<MyQuery> {
+    return defaultQuery;
+  }
 
+  query(options: DataQueryRequest<MyQuery>): Observable<DataQueryResponse> {
+    const observables = options.targets.map((query) => {
       return new Observable<DataQueryResponse>((subscriber) => {
         const frame = new CircularDataFrame({
           append: 'tail',
@@ -65,9 +67,6 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
   }
 
   filterQuery(query: MyQuery): boolean {
-    if (query.hide) {
-      return false;
-    }
-    return true;
+    return !!query.queryText;
   }
 }


### PR DESCRIPTION
Now that [query filtering](https://github.com/grafana/grafana/pull/84656) is being changed in Grafana, it's time to update our examples. There's no longer a need to filter out hidden queries in the data source as this is being taken care of by Grafana. Also, `filterQuery` is now being called from the query runner, so frontend data sources no longer need to do this in the query method. 

While at it, I'm also replacing usage of `defaults(target, defaultQuery)` with the implementation of `getDefaultQuery`. 