### PR TITLE
add app-with-rbac to main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository contains example plugins to showcase different use cases.
 | [app-with-extensions](examples/app-with-extensions)           | Shows how to build an app plugin that extends the Grafana core UI                         |
 | [app-with-extension-point](examples/app-with-extension-point) | Shows how to add an extension point in the plugin UI that can be extended by other plugins |
 | [app-with-scenes](examples/app-with-scenes)                   | Shows how to build a basic app with [@grafana/scenes](https://github.com/grafana/scenes/)  |
+| [app-with-rbac](examples/app-with-rbac)                       | Shows how to use role-based access control (RBAC) in an app plugin                         |
 
 ## Panel plugins
 


### PR DESCRIPTION
The main readme is also missing [app-with-service-account](https://github.com/grafana/grafana-plugin-examples/tree/main/examples/app-with-service-account) -- @gamab shall we list that here, too? 