### PR TITLE
Examples: cleaning up tests for app basic a bit more

### DIFF
--- a/examples/app-basic/package-lock.json
+++ b/examples/app-basic/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@babel/core": "^7.21.4",
         "@grafana/eslint-config": "^6.0.0",
-        "@grafana/plugin-e2e": "^0.21.0",
+        "@grafana/plugin-e2e": "^1.1.1",
         "@grafana/tsconfig": "^1.2.0-rc1",
         "@playwright/test": "^1.41.2",
         "@swc/core": "^1.3.90",
@@ -1112,9 +1112,9 @@
       }
     },
     "node_modules/@grafana/plugin-e2e": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-0.21.0.tgz",
-      "integrity": "sha512-KGq17LhyCoXKaSk2IlkhqLjFlIwrKUVEhuh+ctDeoEsUsroypmhc1OwfLD5dJ/tsWCqNxqcQXBSTSoFD4Mh5xA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-1.1.1.tgz",
+      "integrity": "sha512-liYKdSEbuUIOz5xOSg69maR1MoovK7eZTITz4pFCko2UAVBseFv+pe6phlJO/cz/RK+qTQQMdYzyR2iRtQ7MrA==",
       "dev": true,
       "dependencies": {
         "semver": "^7.5.4",

--- a/examples/app-basic/package.json
+++ b/examples/app-basic/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@babel/core": "^7.21.4",
     "@grafana/eslint-config": "^6.0.0",
-    "@grafana/plugin-e2e": "^0.21.0",
+    "@grafana/plugin-e2e": "^1.1.1",
     "@grafana/tsconfig": "^1.2.0-rc1",
     "@playwright/test": "^1.41.2",
     "@swc/core": "^1.3.90",

--- a/examples/app-basic/tests/appNavigation.spec.ts
+++ b/examples/app-basic/tests/appNavigation.spec.ts
@@ -1,25 +1,25 @@
 import pluginJson from '../src/plugin.json';
-import { test, expect } from '@grafana/plugin-e2e';
+import { test, expect } from './fixtures';
 
 test.describe('navigating app', () => {
-  test('page one should render successfully', async ({ page }) => {
-    await page.goto(`/a/${pluginJson.id}/one`);
+  test('page one should render successfully', async ({ gotoPage, page }) => {
+    await gotoPage('/one');
     await expect(page.getByText('This is page one.')).toBeVisible();
   });
 
-  test('page two should render successfully', async ({ page }) => {
-    await page.goto(`/a/${pluginJson.id}/two`);
+  test('page two should render successfully', async ({ gotoPage, page }) => {
+    await gotoPage('/two');
     await expect(page.getByText('This is page two.')).toBeVisible();
   });
 
-  test('page two should support an id parameter', async ({ page }) => {
-    await page.goto(`/a/${pluginJson.id}/two/123456`);
+  test('page two should support an id parameter', async ({ gotoPage, page }) => {
+    await gotoPage('/two/123456');
     await expect(page.getByText('ID: 123456')).toBeVisible();
   });
 
-  test('page three should render sucessfully', async ({ page }) => {
+  test('page three should render sucessfully', async ({ gotoPage, page }) => {
     // wait for page to successfully render
-    await page.goto(`/a/${pluginJson.id}/one`);
+    await gotoPage('/one');
     await expect(page.getByText('This is page one.')).toBeVisible();
 
     // navigating to page four with full width layout without sidebar menu

--- a/examples/app-basic/tests/appNavigation.spec.ts
+++ b/examples/app-basic/tests/appNavigation.spec.ts
@@ -1,4 +1,3 @@
-import pluginJson from '../src/plugin.json';
 import { test, expect } from './fixtures';
 
 test.describe('navigating app', () => {

--- a/examples/app-basic/tests/fixtures.ts
+++ b/examples/app-basic/tests/fixtures.ts
@@ -13,13 +13,14 @@ export const test = base.extend<AppTestFixture>({
     });
     await use(configPage);
   },
-  gotoPage: async ({ gotoAppPage }, use) =>
-    use((path) =>
+  gotoPage: async ({ gotoAppPage }, use) => {
+    await use((path) =>
       gotoAppPage({
         path,
         pluginId: pluginJson.id,
       })
-    ),
+    );
+  },
 });
 
 export { expect } from '@grafana/plugin-e2e';

--- a/examples/app-basic/tests/fixtures.ts
+++ b/examples/app-basic/tests/fixtures.ts
@@ -7,17 +7,13 @@ type AppTestFixture = {
 };
 
 export const test = base.extend<AppTestFixture>({
-  appConfigPage: async ({ page, selectors, grafanaVersion, request }, use, testInfo) => {
-    const configPage = new AppConfigPage(
-      { page, selectors, grafanaVersion, request, testInfo },
-      {
-        pluginId: pluginJson.id,
-      }
-    );
-    await configPage.goto();
+  appConfigPage: async ({ gotoAppConfigPage }, use) => {
+    const configPage = await gotoAppConfigPage({
+      pluginId: pluginJson.id,
+    });
     await use(configPage);
   },
-  gotoPage: ({ gotoAppPage }, use) =>
+  gotoPage: async ({ gotoAppPage }, use) =>
     use((path) =>
       gotoAppPage({
         path,

--- a/examples/app-basic/tests/fixtures.ts
+++ b/examples/app-basic/tests/fixtures.ts
@@ -1,7 +1,10 @@
-import { AppConfigPage, test as base } from '@grafana/plugin-e2e';
+import { AppConfigPage, AppPage, test as base } from '@grafana/plugin-e2e';
 import pluginJson from '../src/plugin.json';
 
-type AppTestFixture = { appConfigPage: AppConfigPage };
+type AppTestFixture = {
+  appConfigPage: AppConfigPage;
+  gotoPage: (path?: string) => Promise<AppPage>;
+};
 
 export const test = base.extend<AppTestFixture>({
   appConfigPage: async ({ page, selectors, grafanaVersion, request }, use, testInfo) => {
@@ -14,6 +17,13 @@ export const test = base.extend<AppTestFixture>({
     await configPage.goto();
     await use(configPage);
   },
+  gotoPage: ({ gotoAppPage }, use) =>
+    use((path) =>
+      gotoAppPage({
+        path,
+        pluginId: pluginJson.id,
+      })
+    ),
 });
 
 export { expect } from '@grafana/plugin-e2e';


### PR DESCRIPTION
## Description

Cleaned up the navigation tests a bit more. By introducing a `gotoPage` function we can remove the need of suppling plugin id in each test. This is only done once in the fixture.