### PR TITLE
Update script using create-plugin update tool

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -228,7 +228,7 @@ jobs:
 
       - name: Canary - Upgrade @grafana packages using canary_version
         run: |
-          npm install --legacy-peer-deps $(echo $(cat package.json | jq -r --arg version $CANARY_VERSION '["@grafana/eslint-config", "@grafana/tsconfig", "@grafana/scenes", "@grafana/experimental", "@grafana/plugin-e2e", "@grafana/plugin-meta-extractor"] as $blacklist | [(.devDependencies,.dependencies) | keys] | flatten | unique | map(select ( test("^@grafana") ) ) as $deps | $deps - $blacklist | map("\(.)@\($version)") | join(" ")') )
+          npm install --legacy-peer-deps $(echo $(cat package.json | jq -r --arg version $CANARY_VERSION '["@grafana/eslint-config", "@grafana/tsconfig", "@grafana/scenes", "@grafana/experimental", "@grafana/plugin-e2e", "@grafana/plugin-meta-extractor", "@grafana/e2e] as $blacklist | [(.devDependencies,.dependencies) | keys] | flatten | unique | map(select ( test("^@grafana") ) ) as $deps | $deps - $blacklist | map("\(.)@\($version)") | join(" ")') )
           npm install --force --save-optional @swc/core  @swc/core-linux-arm-gnueabihf @swc/core-linux-arm64-gnu @swc/core-linux-arm64-musl @swc/core-linux-x64-gnu @swc/core-linux-x64-musl
         working-directory: ${{ matrix.pluginDir }}
 

--- a/scripts/update-grafana-version.sh
+++ b/scripts/update-grafana-version.sh
@@ -2,12 +2,12 @@
 #
 GRAFANA_VERSION_TARGET=${1:-10.3.1}
 
-dirs=$(find examples -maxdepth 2 -type f -name 'package.json' -not -path '*/node_modules/*' -exec dirname {} \;)
+dirs=$(find examples -type f -name 'package.json' -not -path '*/node_modules/*' -exec dirname {} \;)
 for plugin in $dirs; do
     if [ -d "$plugin" ]; then  # Check if it is indeed a directory
         echo "Processing plugin folder: $plugin"
         # Run the npx command in the plugin directory
-        (cd "$plugin" && npx @grafana/create-plugin@latest update --force && npm install)
+        (cd "$plugin" && npx @grafana/create-plugin@latest update --force && npm install (cd "$plugin" && npx @grafana/create-plugin@latest update --force && npm install && rm -rf node_modules))
     fi
 done
 
@@ -16,7 +16,7 @@ done
 ###############################################
 
 
-plugin_files=$(find examples -maxdepth 3 -type f -name 'plugin.json' -not -path '*/node_modules/*')
+plugin_files=$(find examples -type f -name 'plugin.json' -not -path '*/node_modules/*')
 
 # Iterate over each plugin.json file
 for file in $plugin_files; do

--- a/scripts/update-grafana-version.sh
+++ b/scripts/update-grafana-version.sh
@@ -2,65 +2,13 @@
 #
 GRAFANA_VERSION_TARGET=${1:-10.3.1}
 
-# fail this script if jq is not installed
-command -v jq >/dev/null 2>&1 || { echo >&2 "jq is required but it's not installed.  Aborting."; exit 1; }
-
-
-###############################################
-# Upgrade @grafana/* dependencies
-###############################################
-dirs=$(find examples -type f -name 'package.json' -not -path '*/node_modules/*' -exec dirname {} \;)
-
-# Specify the packages for version upgrade
-upgradePackages=(
-    "@grafana/data"
-    "@grafana/runtime"
-    "@grafana/schema"
-    "@grafana/ui"
-)
-
-# Iterate over each directory
-for dir in $dirs; do
-  # if $dir is the same as the current directory, skip it
-  if [ "$dir" = "." ]; then
-    echo "Skipping $dir"
-    continue
-  fi
-  # Extract the dependencies and devDependencies starting with '@grafana' from the package.json
-  dependencies=$(jq -r '.dependencies | to_entries | map(select(.key | startswith("@grafana"))) | .[].key' "$dir/package.json")
-  devDependencies=$(jq -r '.devDependencies | to_entries | map(select(.key | startswith("@grafana"))) | .[].key' "$dir/package.json")
-
-  # Concatenate the dependencies and devDependencies
-  allDependencies="$dependencies $devDependencies"
-
-  upgradeCommand=""
-  for dep in $allDependencies; do
-        upgradeFlag=false
-        for pkg in "${upgradePackages[@]}"; do
-            if [ "$dep" = "$pkg" ]; then
-                upgradeFlag=true
-                break
-            fi
-        done
-
-        if $upgradeFlag; then
-            upgradeCommand+="$dep@$GRAFANA_VERSION_TARGET "
-        else
-            upgradeCommand+="$dep@latest "
-        fi
-    done
-
-  pushd "$dir" || exit 1
-
-  # detect if a package-lock.json exists
-  if [ -f "package-lock.json" ]; then
-    echo "package-lock.json exists, running npm install"
-    npm install
-    echo "upgrading packages with npm install $upgradeCommand"
-    npm install --save-exact $upgradeCommand
-  fi
-
-  popd || exit 1
+dirs=$(find examples -maxdepth 2 -type f -name 'package.json' -not -path '*/node_modules/*' -exec dirname {} \;)
+for plugin in $dirs; do
+    if [ -d "$plugin" ]; then  # Check if it is indeed a directory
+        echo "Processing plugin folder: $plugin"
+        # Run the npx command in the plugin directory
+        (cd "$plugin" && npx @grafana/create-plugin@latest update --force && npm install)
+    fi
 done
 
 ###############################################
@@ -68,15 +16,15 @@ done
 ###############################################
 
 
-plugin_files=$(find examples -type f -name 'plugin.json' -not -path '*/node_modules/*')
+plugin_files=$(find examples -maxdepth 3 -type f -name 'plugin.json' -not -path '*/node_modules/*')
 
 # Iterate over each plugin.json file
 for file in $plugin_files; do
     # Get the current value of dependencies.grafanaDependency using jq
     current_dependency=$(jq -r '.dependencies.grafanaDependency' "$file")
-
+    target_version=$(get_newer_version "$(echo $current_dependency | sed -n 's|[=<>~!]*\([0-9]*.[0-9]*.[0-9]*\)|\1|p')" "$GRAFANA_VERSION_TARGET")
     # Modify the property to >$GRAFANA_VERSION_TARGET using jq and update the file
-    modified_dependency=$(echo "$current_dependency" | jq -n --arg target ">=$GRAFANA_VERSION_TARGET" '$target')
+    modified_dependency=$(echo "$current_dependency" | jq -n --arg target ">=$target_version" '$target')
     jq --argjson modified "$modified_dependency" '.dependencies.grafanaDependency = $modified' "$file" >"$file.tmp" && mv "$file.tmp" "$file"
 done
 
@@ -84,15 +32,21 @@ done
 # Upgrade docker-compose files
 ###############################################
 # Find the docker-compose.yaml files excluding node_modules
-files=$(find examples -type f -name "docker-compose.yaml" -not -path "*node_modules*")
+files=$(find examples -maxdepth 2 -type f -name "docker-compose.yaml" -not -path "*node_modules*")
+# Make a wrapper to support Linux and MacOS
+case $(sed --help 2>&1) in
+  *GNU*) sed_i () { sed -i "$@"; };;
+  *) sed_i () { sed -i '' "$@"; };;
+esac
 
+get_newer_version () { printf "%s\n" "$@" | sort --version-sort | tail -1 ; }
 # Iterate over each file and modify the grafana_version field
 for file in $files; do
     # Check if the file contains the grafana_version field
     if grep -q "grafana_version:" "$file"; then
         # Replace the grafana_version field with the target version
         # sed -i "s/grafana_version:.*/grafana_version: ${GRAFANA_VERSION_TARGET}/" "$file"
-        sed -i "s/\(grafana_version: \)\${GRAFANA_VERSION:-[^}]*}/\1\${GRAFANA_VERSION:-$GRAFANA_VERSION_TARGET}/" "$file"
+        sed_i "s/\(grafana_version: \)\${GRAFANA_VERSION:-[^}]*}/\1\${GRAFANA_VERSION:-$target_version}/" "$file"
         echo "Modified $file"
     fi
 done


### PR DESCRIPTION
History:
There was a script which @academo wrote to update grafana packages. It took desired grafana version and updated specific packages to this version.

Work:
While fixing problems for mac OS I added some improvements to check first if the current version is newer than target version and leave it as it is to avoid downgrading

Latest updates:
But we decide to use npx create-plugin@latest update to update plugins from now on, because in the future we want to make it automatically. 
So this PR is a first step to do it. After there will be several PRs about updates themself 