### PR TITLE
app-with-extension-point: use the hooks instead of the getter

### DIFF
--- a/examples/app-with-extension-point/docker-compose.yaml
+++ b/examples/app-with-extension-point/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       context: ./.config
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
-        grafana_version: ${GRAFANA_VERSION:-10.3.3}
+        grafana_version: ${GRAFANA_VERSION:-main}
     ports:
       - 3000:3000/tcp
     volumes:

--- a/examples/app-with-extension-point/package-lock.json
+++ b/examples/app-with-extension-point/package-lock.json
@@ -10,10 +10,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",
-        "@grafana/data": "10.3.3",
-        "@grafana/runtime": "10.3.3",
-        "@grafana/schema": "10.3.3",
-        "@grafana/ui": "10.3.3",
+        "@grafana/data": "11.1.0-179609",
+        "@grafana/runtime": "11.1.0-179609",
+        "@grafana/schema": "11.0.0",
+        "@grafana/ui": "11.1.0-179609",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-router-dom": "^5.2.0",
@@ -594,9 +594,9 @@
       "dev": true
     },
     "node_modules/@braintree/sanitize-url": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz",
-      "integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg=="
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.0.1.tgz",
+      "integrity": "sha512-URg8UM6lfC9ZYqFipItRSxYJdgpU5d2Z4KnjsJ+rj6tgAmGme7E+PQNCiud8g0HDaZKMovu2qjfa0f5Ge0Vlsg=="
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -682,14 +682,14 @@
       "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "node_modules/@emotion/react": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.1.tgz",
-      "integrity": "sha512-5mlW1DquU5HaxjLkfkGN1GA/fvVGdyHURRiX/0FHl2cfIfRxSOfmxEH5YS43edp0OldZrZ+dkBKbngxcNCdZvA==",
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
+      "integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
         "@emotion/cache": "^11.11.0",
-        "@emotion/serialize": "^1.1.2",
+        "@emotion/serialize": "^1.1.3",
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
         "@emotion/utils": "^1.2.1",
         "@emotion/weak-memoize": "^0.3.1",
@@ -864,17 +864,12 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.1.tgz",
-      "integrity": "sha512-42UH54oPZHPdRHdw6BgoBD6cg/eVTmVrFcgeRDM3jbO7uxSoipVcmcIGFcA5jmOHO5apcyvBhkSKES3fQJnu7A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.2.tgz",
+      "integrity": "sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==",
       "dependencies": {
         "@floating-ui/utils": "^0.2.0"
       }
-    },
-    "node_modules/@floating-ui/core/node_modules/@floating-ui/utils": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
-      "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
     },
     "node_modules/@floating-ui/dom": {
       "version": "1.6.5",
@@ -885,19 +880,14 @@
         "@floating-ui/utils": "^0.2.0"
       }
     },
-    "node_modules/@floating-ui/dom/node_modules/@floating-ui/utils": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
-      "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
-    },
     "node_modules/@floating-ui/react": {
-      "version": "0.26.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.4.tgz",
-      "integrity": "sha512-pRiEz+SiPyfTcckAtLkEf3KJ/sUbB4X4fWMcDm27HT2kfAq+dH+hMc2VoOkNaGpDE35a2PKo688ugWeHaToL3g==",
+      "version": "0.26.14",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.14.tgz",
+      "integrity": "sha512-I2EhfezC+H0WfkMEkCcF9+++PU1Wq08bDKhHHGIoBZVCciiftEQHgrSI4dTUTsa7446SiIVW0gWATliIlVNgfg==",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.0.3",
-        "@floating-ui/utils": "^0.1.5",
-        "tabbable": "^6.0.1"
+        "@floating-ui/react-dom": "^2.0.0",
+        "@floating-ui/utils": "^0.2.0",
+        "tabbable": "^6.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -905,9 +895,9 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.9.tgz",
-      "integrity": "sha512-q0umO0+LQK4+p6aGyvzASqKbKOJcAHJ7ycE9CuUvfx3s9zTHWmGJTPOIlM/hmSBfUfg/XfY5YhLBLR/LHwShQQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.0.tgz",
+      "integrity": "sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==",
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
       },
@@ -917,14 +907,14 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
-      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
+      "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
-      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.0.0.tgz",
+      "integrity": "sha512-rRqXOqdFmk7RYvj4khklyqzcfQl9vEL/usogncBHRZfZBDOwMGuSRNFl02fu5KGHXdbinju+YXyuR+Nk8xlr/g==",
       "dependencies": {
         "@formatjs/intl-localematcher": "0.5.4",
         "tslib": "^2.4.0"
@@ -939,21 +929,21 @@
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.7.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.6.tgz",
-      "integrity": "sha512-etVau26po9+eewJKYoiBKP6743I1br0/Ie00Pb/S/PtmYfmjTcOn2YCh2yNkSZI12h6Rg+BOgQYborXk46BvkA==",
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.8.tgz",
+      "integrity": "sha512-nBZJYmhpcSX0WeJ5SDYUkZ42AgR3xiyhNCsQweFx3cz/ULJjym8bHAzWKvG5e2+1XO98dBYC0fWeeAECAVSwLA==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
-        "@formatjs/icu-skeleton-parser": "1.8.0",
+        "@formatjs/ecma402-abstract": "2.0.0",
+        "@formatjs/icu-skeleton-parser": "1.8.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.0.tgz",
-      "integrity": "sha512-QWLAYvM0n8hv7Nq5BEs4LKIjevpVpbGLAJgOaYzg9wABEoX1j0JO1q2/jVkO6CVlq0dbsxZCngS5aXbysYueqA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.2.tgz",
+      "integrity": "sha512-k4ERKgw7aKGWJZgTarIcNEmvyTVD9FYh0mTrrBMHZ1b8hUu6iOJ4SzsZlo3UNAvHYa+PnvntIwRPt1/vy4nA9Q==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/ecma402-abstract": "2.0.0",
         "tslib": "^2.4.0"
       }
     },
@@ -966,75 +956,72 @@
       }
     },
     "node_modules/@grafana/data": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-10.3.3.tgz",
-      "integrity": "sha512-TkTxe/gHvLenTayDjqfM70kqRO18RyAyHCRlCGOlLOQF1J3YRqSvEnr91Izo1AmKOsWHr8IogXAEV1OjcNOmVg==",
+      "version": "11.1.0-179609",
+      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-11.1.0-179609.tgz",
+      "integrity": "sha512-oeUPFJrpXl1m+giLKeq4ckGWGuBv9qpZ6WmH983jdP+TBZFcYA7fBYavNzLC3vUBTIKOxNh4zsUxV0xVNB20SA==",
       "dependencies": {
-        "@braintree/sanitize-url": "6.0.2",
-        "@grafana/schema": "10.3.3",
+        "@braintree/sanitize-url": "7.0.1",
+        "@grafana/schema": "11.1.0-179609",
         "@types/d3-interpolate": "^3.0.0",
-        "@types/string-hash": "1.1.1",
+        "@types/string-hash": "1.1.3",
         "d3-interpolate": "3.0.1",
-        "date-fns": "2.30.0",
-        "dompurify": "^2.4.3",
+        "date-fns": "3.6.0",
+        "dompurify": "^3.0.0",
         "eventemitter3": "5.0.1",
         "fast_array_intersect": "1.1.0",
         "history": "4.10.1",
         "lodash": "4.17.21",
-        "marked": "5.1.1",
-        "marked-mangle": "1.1.0",
-        "moment": "2.29.4",
-        "moment-timezone": "0.5.43",
+        "marked": "12.0.2",
+        "marked-mangle": "1.1.7",
+        "moment": "2.30.1",
+        "moment-timezone": "0.5.45",
         "ol": "7.4.0",
         "papaparse": "5.4.1",
-        "react-use": "17.4.0",
-        "regenerator-runtime": "0.14.0",
+        "react-use": "17.5.0",
         "rxjs": "7.8.1",
         "string-hash": "^1.1.3",
         "tinycolor2": "1.6.0",
-        "tslib": "2.6.0",
-        "uplot": "1.6.28",
+        "tslib": "2.6.2",
+        "uplot": "1.6.30",
         "xss": "^1.0.14"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@grafana/data/node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+    "node_modules/@grafana/data/node_modules/@grafana/schema": {
+      "version": "11.1.0-179609",
+      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-11.1.0-179609.tgz",
+      "integrity": "sha512-d+sRZore4I5T3yecdzVIZH7zxJnan1UygqYNIGiYZ/gnEVa40Zv4I5sHnuiCdpKrPjEecG2Y+3/qiMePsE1S4g==",
+      "dependencies": {
+        "tslib": "2.6.2"
+      }
     },
     "node_modules/@grafana/data/node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@grafana/e2e-selectors": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-10.3.3.tgz",
-      "integrity": "sha512-VsvdMldC3ARQp5axUAHWVHpUoYwZSTf9wfcT21zh+hxGbuiPbdDS9VqZFKpwVtJtHGjtvnKBtWKODD7ArQyOOw==",
+      "version": "11.1.0-179609",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-11.1.0-179609.tgz",
+      "integrity": "sha512-xLXQV6NFe9OeEkpn1KRnsC8qz1mV852MPUD12KgOef0B4rvYcLH1Id8SwRLc+jKTS6bQcksGns2zLEJD9IcOeg==",
       "dependencies": {
-        "@grafana/tsconfig": "^1.2.0-rc1",
-        "tslib": "2.6.0",
-        "typescript": "5.2.2"
+        "@grafana/tsconfig": "^1.3.0-rc1",
+        "tslib": "2.6.2",
+        "typescript": "5.4.5"
       }
     },
-    "node_modules/@grafana/e2e-selectors/node_modules/@grafana/tsconfig": {
-      "version": "1.2.0-rc1",
-      "resolved": "https://registry.npmjs.org/@grafana/tsconfig/-/tsconfig-1.2.0-rc1.tgz",
-      "integrity": "sha512-+SgQeBQ1pT6D/E3/dEdADqTrlgdIGuexUZ8EU+8KxQFKUeFeU7/3z/ayI2q/wpJ/Kr6WxBBNlrST6aOKia19Ag=="
-    },
     "node_modules/@grafana/e2e-selectors/node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@grafana/e2e-selectors/node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1073,20 +1060,20 @@
       }
     },
     "node_modules/@grafana/faro-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.7.1.tgz",
-      "integrity": "sha512-SnRPhPVVpnEqS6aYU8D88wboO4++U4GSR4XLxEsgSCycGqORzK8OiFThJaTICsNGcAEM9HXLawKWPIjro0ounQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-core/-/faro-core-1.7.3.tgz",
+      "integrity": "sha512-SIyYws35nB4XFMBL2BEUopOw98XJ6WFzftK0LFYBqaDC+NjR7xn2XJ8ien79EmOOK+xXMRRR/KJDHdp/CMj1dw==",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/otlp-transformer": "^0.48.0"
       }
     },
     "node_modules/@grafana/faro-web-sdk": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.7.1.tgz",
-      "integrity": "sha512-zdot5fg7pSS482Dh5B5D1oOWqa5Xl3a0rNOkz+EtdDSw65GaYmhEzi+trv57OXBEGBFdAfW4QxRjfWYoogxlgQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@grafana/faro-web-sdk/-/faro-web-sdk-1.7.3.tgz",
+      "integrity": "sha512-fEOUY/JpUtkgSYcRivlqQ+YQ07arNu+J8wFSL3CXbp29eeP4zKVDyGDuGzSGyupQ3jV2xmAsQFdCYfiGoZtJSg==",
       "dependencies": {
-        "@grafana/faro-core": "^1.7.1",
+        "@grafana/faro-core": "^1.7.3",
         "ua-parser-js": "^1.0.32",
         "web-vitals": "^3.1.1"
       }
@@ -1135,19 +1122,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@grafana/plugin-e2e/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@grafana/plugin-e2e/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -1181,123 +1155,125 @@
       }
     },
     "node_modules/@grafana/runtime": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@grafana/runtime/-/runtime-10.3.3.tgz",
-      "integrity": "sha512-OtRLmRGnyXD3pRDh26dRThUig1WV8jUBGAiwnPmCwalRr/l4P3NhgwfirwZGDAuXjSb5HT79w0qb0nsWpcrXBg==",
+      "version": "11.1.0-179609",
+      "resolved": "https://registry.npmjs.org/@grafana/runtime/-/runtime-11.1.0-179609.tgz",
+      "integrity": "sha512-dYnqzEAI7FMHGv9JsVZbwz8eUg0WKlvBYNVEZc+UYui1U0YMx3yIb40wpfGPKjU5efZSLzioNjTZ89BAFB0+Zw==",
       "dependencies": {
-        "@grafana/data": "10.3.3",
-        "@grafana/e2e-selectors": "10.3.3",
-        "@grafana/faro-web-sdk": "^1.3.5",
-        "@grafana/ui": "10.3.3",
+        "@grafana/data": "11.1.0-179609",
+        "@grafana/e2e-selectors": "11.1.0-179609",
+        "@grafana/faro-web-sdk": "^1.3.6",
+        "@grafana/schema": "11.1.0-179609",
+        "@grafana/ui": "11.1.0-179609",
         "history": "4.10.1",
         "lodash": "4.17.21",
         "rxjs": "7.8.1",
-        "systemjs": "6.14.2",
-        "systemjs-cjs-extra": "0.2.0",
-        "tslib": "2.6.0"
+        "tslib": "2.6.2"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@grafana/runtime/node_modules/@grafana/schema": {
+      "version": "11.1.0-179609",
+      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-11.1.0-179609.tgz",
+      "integrity": "sha512-d+sRZore4I5T3yecdzVIZH7zxJnan1UygqYNIGiYZ/gnEVa40Zv4I5sHnuiCdpKrPjEecG2Y+3/qiMePsE1S4g==",
+      "dependencies": {
+        "tslib": "2.6.2"
       }
     },
     "node_modules/@grafana/runtime/node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@grafana/schema": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-10.3.3.tgz",
-      "integrity": "sha512-u5jIBZe6lLsGoFmERJZ35+NTP72gJYYKgUKdiO48l78uSFAmPFgR/t2MeNlY5wJTRgi54GB7giMwzrXnM4qlFg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-11.0.0.tgz",
+      "integrity": "sha512-hqMZp+5Eta9Rpm/wrZFzzUPUJul3HVM9Bd9YPT6wGsrhdHzdrG/1ANrph9e8YCiVoyWh91tX/+qbsYrzIw68kA==",
       "dependencies": {
-        "tslib": "2.6.0"
+        "tslib": "2.6.2"
       }
     },
     "node_modules/@grafana/schema/node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@grafana/tsconfig": {
       "version": "1.3.0-rc1",
       "resolved": "https://registry.npmjs.org/@grafana/tsconfig/-/tsconfig-1.3.0-rc1.tgz",
-      "integrity": "sha512-bi+qFOptejg/a2/WmCDVxQLQtobhKd3y+B6mxFBOMmzElqgr30MPnN60THTou6dGwtfw+ExX1H5FGm9DM35Qrw==",
-      "dev": true
+      "integrity": "sha512-bi+qFOptejg/a2/WmCDVxQLQtobhKd3y+B6mxFBOMmzElqgr30MPnN60THTou6dGwtfw+ExX1H5FGm9DM35Qrw=="
     },
     "node_modules/@grafana/ui": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-10.3.3.tgz",
-      "integrity": "sha512-E8z68sKLNNrxyrh/MGBJ+RNwZVBcJiEy1PTffoXqt1/I/iBj6WF4dFiFrzjESDVHFedGWbqpcnelexWASnMVuA==",
+      "version": "11.1.0-179609",
+      "resolved": "https://registry.npmjs.org/@grafana/ui/-/ui-11.1.0-179609.tgz",
+      "integrity": "sha512-qxYfbLSU2NRBabO/yjAWiK5VrVJjCpoqlaMUyGa6W3cStePhMMzwFFZhv+ivVezCorCXDNq+9XB04ltHjsCJnw==",
       "dependencies": {
         "@emotion/css": "11.11.2",
-        "@emotion/react": "11.11.1",
-        "@floating-ui/react": "0.26.4",
-        "@grafana/data": "10.3.3",
-        "@grafana/e2e-selectors": "10.3.3",
-        "@grafana/faro-web-sdk": "^1.3.5",
-        "@grafana/schema": "10.3.3",
-        "@leeoniya/ufuzzy": "1.0.13",
+        "@emotion/react": "11.11.4",
+        "@floating-ui/react": "0.26.14",
+        "@grafana/data": "11.1.0-179609",
+        "@grafana/e2e-selectors": "11.1.0-179609",
+        "@grafana/faro-web-sdk": "^1.3.6",
+        "@grafana/schema": "11.1.0-179609",
+        "@leeoniya/ufuzzy": "1.0.14",
         "@monaco-editor/react": "4.6.0",
         "@popperjs/core": "2.11.8",
-        "@react-aria/button": "3.8.0",
-        "@react-aria/dialog": "3.5.3",
-        "@react-aria/focus": "3.13.0",
-        "@react-aria/menu": "3.10.0",
-        "@react-aria/overlays": "3.15.0",
-        "@react-aria/utils": "3.18.0",
-        "@react-stately/menu": "3.5.3",
+        "@react-aria/dialog": "3.5.14",
+        "@react-aria/focus": "3.17.1",
+        "@react-aria/overlays": "3.22.1",
+        "@react-aria/utils": "3.24.1",
         "ansicolor": "1.1.100",
         "calculate-size": "1.1.1",
-        "classnames": "2.3.2",
-        "d3": "7.8.5",
-        "date-fns": "2.30.0",
+        "classnames": "2.5.1",
+        "d3": "7.9.0",
+        "date-fns": "3.6.0",
         "hoist-non-react-statics": "3.3.2",
-        "i18next": "^22.0.0",
+        "i18next": "^23.0.0",
         "i18next-browser-languagedetector": "^7.0.2",
-        "immutable": "4.3.1",
+        "immutable": "4.3.6",
         "is-hotkey": "0.2.0",
-        "jquery": "3.7.0",
+        "jquery": "3.7.1",
         "lodash": "4.17.21",
         "micro-memoize": "^4.1.2",
-        "moment": "2.29.4",
-        "monaco-editor": "0.34.0",
+        "moment": "2.30.1",
+        "monaco-editor": "0.34.1",
         "ol": "7.4.0",
         "prismjs": "1.29.0",
-        "rc-cascader": "3.20.0",
-        "rc-drawer": "6.5.2",
-        "rc-slider": "10.3.1",
+        "rc-cascader": "3.25.0",
+        "rc-drawer": "7.1.0",
+        "rc-slider": "10.6.2",
         "rc-time-picker": "^3.7.3",
-        "rc-tooltip": "6.1.1",
+        "rc-tooltip": "6.2.0",
         "react-beautiful-dnd": "13.1.1",
-        "react-calendar": "4.6.0",
+        "react-calendar": "4.8.0",
         "react-colorful": "5.6.1",
         "react-custom-scrollbars-2": "4.5.0",
         "react-dropzone": "14.2.3",
         "react-highlight-words": "0.20.0",
         "react-hook-form": "^7.49.2",
-        "react-i18next": "^12.0.0",
+        "react-i18next": "^14.0.0",
         "react-inlinesvg": "3.0.2",
-        "react-loading-skeleton": "3.3.1",
-        "react-popper": "2.3.0",
+        "react-loading-skeleton": "3.4.0",
         "react-router-dom": "5.3.3",
-        "react-select": "5.7.4",
+        "react-select": "5.8.0",
         "react-table": "7.8.0",
         "react-transition-group": "4.4.5",
-        "react-use": "17.4.0",
-        "react-window": "1.8.9",
+        "react-use": "17.5.0",
+        "react-window": "1.8.10",
         "rxjs": "7.8.1",
         "slate": "0.47.9",
         "slate-plain-serializer": "0.7.13",
         "slate-react": "0.22.10",
         "tinycolor2": "1.6.0",
-        "tslib": "2.6.0",
-        "uplot": "1.6.28",
-        "uuid": "9.0.0"
+        "tslib": "2.6.2",
+        "uplot": "1.6.30",
+        "uuid": "9.0.1"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@grafana/ui/node_modules/@emotion/css": {
@@ -1310,6 +1286,14 @@
         "@emotion/serialize": "^1.1.2",
         "@emotion/sheet": "^1.2.2",
         "@emotion/utils": "^1.2.1"
+      }
+    },
+    "node_modules/@grafana/ui/node_modules/@grafana/schema": {
+      "version": "11.1.0-179609",
+      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-11.1.0-179609.tgz",
+      "integrity": "sha512-d+sRZore4I5T3yecdzVIZH7zxJnan1UygqYNIGiYZ/gnEVa40Zv4I5sHnuiCdpKrPjEecG2Y+3/qiMePsE1S4g==",
+      "dependencies": {
+        "tslib": "2.6.2"
       }
     },
     "node_modules/@grafana/ui/node_modules/react-router": {
@@ -1364,9 +1348,9 @@
       }
     },
     "node_modules/@grafana/ui/node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -1402,34 +1386,34 @@
       "dev": true
     },
     "node_modules/@internationalized/date": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.5.3.tgz",
-      "integrity": "sha512-X9bi8NAEHAjD8yzmPYT2pdJsbe+tYSEBAfowtlxJVJdZR3aK8Vg7ZUT1Fm5M47KLzp/M1p1VwAaeSma3RT7biw==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.5.4.tgz",
+      "integrity": "sha512-qoVJVro+O0rBaw+8HPjUB1iH8Ihf8oziEnqMnvhJUSuVIrHOuZ6eNLHNvzXJKUvAtaDiqMnRlg8Z2mgh09BlUw==",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@internationalized/message": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.3.tgz",
-      "integrity": "sha512-jba3kGxnh4hN4zoeJZuMft99Ly1zbmon4fyDz3VAmO39Kb5Aw+usGub7oU/sGoBIcVQ7REEwsvjIWtIO1nitbw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.4.tgz",
+      "integrity": "sha512-Dygi9hH1s7V9nha07pggCkvmRfDd3q2lWnMGvrJyrOwYMe1yj4D2T9BoH9I6MGR7xz0biQrtLPsqUkqXzIrBOw==",
       "dependencies": {
         "@swc/helpers": "^0.5.0",
         "intl-messageformat": "^10.1.0"
       }
     },
     "node_modules/@internationalized/number": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.5.2.tgz",
-      "integrity": "sha512-4FGHTi0rOEX1giSkt5MH4/te0eHBq3cvAYsfLlpguV6pzJAReXymiYpE5wPCqKqjkUO3PIsyvk+tBiIV1pZtbA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.5.3.tgz",
+      "integrity": "sha512-rd1wA3ebzlp0Mehj5YTuTI50AQEx80gWFyHcQu+u91/5NgdwBecO8BH6ipPfE+lmQ9d63vpB3H9SHoIUiupllw==",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@internationalized/string": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.2.tgz",
-      "integrity": "sha512-5xy2JfSQyGqL9FDIdJXVjoKSBBDJR4lvwoCbqKhc5hQZ/qSLU/OlONCmrJPcSH0zxh88lXJMzbOAk8gJ48JBFw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.3.tgz",
+      "integrity": "sha512-9kpfLoA8HegiWTeCbR2livhdVeKobCnVv8tlJ6M2jF+4tcMqDo94ezwlnrUANBWPgd8U7OXIHCk2Ov2qhk4KXw==",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -2850,10 +2834,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -2866,9 +2849,9 @@
       }
     },
     "node_modules/@leeoniya/ufuzzy": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@leeoniya/ufuzzy/-/ufuzzy-1.0.13.tgz",
-      "integrity": "sha512-w7cOuME1F8e4TOrSAGQWPczj60eIcQiU31X1RU65yiZBz1zpDWfynVJUw8d2QzhkUsEObAV0nN4RTIqxpCvJGg=="
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@leeoniya/ufuzzy/-/ufuzzy-1.0.14.tgz",
+      "integrity": "sha512-/xF4baYuCQMo+L/fMSUrZnibcu0BquEGnbxfVPiZhs/NbJeKj4c/UmFpQzW9Us0w45ui/yYW3vyaqawhNYsTzA=="
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
@@ -3148,9 +3131,9 @@
       }
     },
     "node_modules/@rc-component/trigger": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-1.18.3.tgz",
-      "integrity": "sha512-Ksr25pXreYe1gX6ayZ1jLrOrl9OAUHUqnuhEx6MeHnNa1zVM5Y2Aj3Q35UrER0ns8D2cJYtmJtVli+i+4eKrvA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.1.1.tgz",
+      "integrity": "sha512-UjHkedkgtEcgQu87w1VuWug1idoDJV7VUt0swxHXRcmei2uu1AuUzGBPEUlmOmXGJ+YtTgZfVLi7kuAUKoZTMA==",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
         "@rc-component/portal": "^1.1.0",
@@ -3167,239 +3150,96 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/@react-aria/button": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.8.0.tgz",
-      "integrity": "sha512-QdvXTQgn+QEWOHoMbUIPXSBIN5P2r1zthRvqDJMTCzuT0I6LbNAq7RoojEbRrcn0DbTa/nZPzOOYsZXjgteRdw==",
-      "dependencies": {
-        "@react-aria/focus": "^3.13.0",
-        "@react-aria/interactions": "^3.16.0",
-        "@react-aria/utils": "^3.18.0",
-        "@react-stately/toggle": "^3.6.0",
-        "@react-types/button": "^3.7.3",
-        "@react-types/shared": "^3.18.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
     "node_modules/@react-aria/dialog": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.3.tgz",
-      "integrity": "sha512-wXpAqnt6TtR4X/5Xk5HCTBM0qyPcF2bXFQ5z2gSwl1olgoQ5znZEgMqMLbMmwb4dsWGGtAueULs6fVZk766ygA==",
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.14.tgz",
+      "integrity": "sha512-oqDCjQ8hxe3GStf48XWBf2CliEnxlR9GgSYPHJPUc69WBj68D9rVcCW3kogJnLAnwIyf3FnzbX4wSjvUa88sAQ==",
       "dependencies": {
-        "@react-aria/focus": "^3.13.0",
-        "@react-aria/overlays": "^3.15.0",
-        "@react-aria/utils": "^3.18.0",
-        "@react-stately/overlays": "^3.6.0",
-        "@react-types/dialog": "^3.5.3",
-        "@react-types/shared": "^3.18.1",
+        "@react-aria/focus": "^3.17.1",
+        "@react-aria/overlays": "^3.22.1",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/dialog": "^3.5.10",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
     "node_modules/@react-aria/focus": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.13.0.tgz",
-      "integrity": "sha512-9DW7RqgbFWiImZmkmTIJGe9LrQBqEeLYwlKY+F1FTVXerIPiCCQ3JO3ESEa4lFMmkaHoueFLUrq2jkYjRNqoTw==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.17.1.tgz",
+      "integrity": "sha512-FLTySoSNqX++u0nWZJPPN5etXY0WBxaIe/YuL/GTEeuqUIuC/2bJSaw5hlsM6T2yjy6Y/VAxBcKSdAFUlU6njQ==",
       "dependencies": {
-        "@react-aria/interactions": "^3.16.0",
-        "@react-aria/utils": "^3.18.0",
-        "@react-types/shared": "^3.18.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0",
-        "clsx": "^1.1.1"
+        "clsx": "^2.0.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
     "node_modules/@react-aria/i18n": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.11.0.tgz",
-      "integrity": "sha512-dnopopsYKy2cd2dB2LdnmdJ58evKKcNCtiscWl624XFSbq2laDrYIQ4umrMhBxaKD7nDQkqydVBe6HoQKPzvJw==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.11.1.tgz",
+      "integrity": "sha512-vuiBHw1kZruNMYeKkTGGnmPyMnM5T+gT8bz97H1FqIq1hQ6OPzmtBZ6W6l6OIMjeHI5oJo4utTwfZl495GALFQ==",
       "dependencies": {
-        "@internationalized/date": "^3.5.3",
-        "@internationalized/message": "^3.1.3",
-        "@internationalized/number": "^3.5.2",
-        "@internationalized/string": "^3.2.2",
-        "@react-aria/ssr": "^3.9.3",
-        "@react-aria/utils": "^3.24.0",
-        "@react-types/shared": "^3.23.0",
+        "@internationalized/date": "^3.5.4",
+        "@internationalized/message": "^3.1.4",
+        "@internationalized/number": "^3.5.3",
+        "@internationalized/string": "^3.2.3",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/i18n/node_modules/@react-aria/utils": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.24.0.tgz",
-      "integrity": "sha512-JAxkPhK5fCvFVNY2YG3TW3m1nTzwRcbz7iyTSkUzLFat4N4LZ7Kzh7NMHsgeE/oMOxd8zLY+XsUxMu/E/2GujA==",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.3",
-        "@react-stately/utils": "^3.10.0",
-        "@react-types/shared": "^3.23.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/i18n/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@react-aria/interactions": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.2.tgz",
-      "integrity": "sha512-Ju706DtoEmI/2vsfu9DCEIjDqsRBVLm/wmt2fr0xKbBca7PtmK8daajxFWz+eTq+EJakvYfLr7gWgLau9HyWXg==",
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.3.tgz",
+      "integrity": "sha512-BWIuf4qCs5FreDJ9AguawLVS0lV9UU+sK4CCnbCNNmYqOWY+1+gRXCsnOM32K+oMESBxilAjdHW5n1hsMqYMpA==",
       "dependencies": {
-        "@react-aria/ssr": "^3.9.3",
-        "@react-aria/utils": "^3.24.0",
-        "@react-types/shared": "^3.23.0",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/interactions/node_modules/@react-aria/utils": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.24.0.tgz",
-      "integrity": "sha512-JAxkPhK5fCvFVNY2YG3TW3m1nTzwRcbz7iyTSkUzLFat4N4LZ7Kzh7NMHsgeE/oMOxd8zLY+XsUxMu/E/2GujA==",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.3",
-        "@react-stately/utils": "^3.10.0",
-        "@react-types/shared": "^3.23.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/interactions/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@react-aria/menu": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.10.0.tgz",
-      "integrity": "sha512-zOOOXvx21aGSxZsXvLa3NV48hLk0jBC/zu5WZHT0Mo/wAe0+43f8p/U3AT8Gc4WnxYbIestcdLaIwgeagSoLtQ==",
-      "dependencies": {
-        "@react-aria/focus": "^3.13.0",
-        "@react-aria/i18n": "^3.8.0",
-        "@react-aria/interactions": "^3.16.0",
-        "@react-aria/overlays": "^3.15.0",
-        "@react-aria/selection": "^3.16.0",
-        "@react-aria/utils": "^3.18.0",
-        "@react-stately/collections": "^3.9.0",
-        "@react-stately/menu": "^3.5.3",
-        "@react-stately/tree": "^3.7.0",
-        "@react-types/button": "^3.7.3",
-        "@react-types/menu": "^3.9.2",
-        "@react-types/shared": "^3.18.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
     "node_modules/@react-aria/overlays": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.15.0.tgz",
-      "integrity": "sha512-MeLn74GvXZfi881NSx5sSd5eTduki/PMk4vPvMNp2Xm+9nGHm0FbGu2GMIGgarYy5JC7l/bOO7H01YrS4AozPg==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.22.1.tgz",
+      "integrity": "sha512-GHiFMWO4EQ6+j6b5QCnNoOYiyx1Gk8ZiwLzzglCI4q1NY5AG2EAmfU4Z1+Gtrf2S5Y0zHbumC7rs9GnPoGLUYg==",
       "dependencies": {
-        "@react-aria/focus": "^3.13.0",
-        "@react-aria/i18n": "^3.8.0",
-        "@react-aria/interactions": "^3.16.0",
-        "@react-aria/ssr": "^3.7.0",
-        "@react-aria/utils": "^3.18.0",
-        "@react-aria/visually-hidden": "^3.8.2",
-        "@react-stately/overlays": "^3.6.0",
-        "@react-types/button": "^3.7.3",
-        "@react-types/overlays": "^3.8.0",
-        "@react-types/shared": "^3.18.1",
+        "@react-aria/focus": "^3.17.1",
+        "@react-aria/i18n": "^3.11.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-aria/utils": "^3.24.1",
+        "@react-aria/visually-hidden": "^3.8.12",
+        "@react-stately/overlays": "^3.6.7",
+        "@react-types/button": "^3.9.4",
+        "@react-types/overlays": "^3.8.7",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/selection": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.18.0.tgz",
-      "integrity": "sha512-6ZvRuS9OHe56UVTb/qnsZ1TOxpZH9gRlX6eGG3Pt4LZK12wcvs13Uz2OvB2aYQHu0KPAua9ACnPh94xvXzQIlQ==",
-      "dependencies": {
-        "@react-aria/focus": "^3.17.0",
-        "@react-aria/i18n": "^3.11.0",
-        "@react-aria/interactions": "^3.21.2",
-        "@react-aria/utils": "^3.24.0",
-        "@react-stately/selection": "^3.15.0",
-        "@react-types/shared": "^3.23.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/selection/node_modules/@react-aria/focus": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.17.0.tgz",
-      "integrity": "sha512-aRzBw1WTUkcIV3xFrqPA6aB8ZVt3XyGpTaSHAypU0Pgoy2wRq9YeJYpbunsKj9CJmskuffvTqXwAjTcaQish1Q==",
-      "dependencies": {
-        "@react-aria/interactions": "^3.21.2",
-        "@react-aria/utils": "^3.24.0",
-        "@react-types/shared": "^3.23.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/selection/node_modules/@react-aria/utils": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.24.0.tgz",
-      "integrity": "sha512-JAxkPhK5fCvFVNY2YG3TW3m1nTzwRcbz7iyTSkUzLFat4N4LZ7Kzh7NMHsgeE/oMOxd8zLY+XsUxMu/E/2GujA==",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.3",
-        "@react-stately/utils": "^3.10.0",
-        "@react-types/shared": "^3.23.0",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/selection/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@react-aria/ssr": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.3.tgz",
-      "integrity": "sha512-5bUZ93dmvHFcmfUcEN7qzYe8yQQ8JY+nHN6m9/iSDCQ/QmCiE0kWXYwhurjw5ch6I8WokQzx66xKIMHBAa4NNA==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.4.tgz",
+      "integrity": "sha512-4jmAigVq409qcJvQyuorsmBR4+9r3+JEC60wC+Y0MZV0HCtTmm8D9guYXlJMdx0SSkgj0hHAyFm/HvPNFofCoQ==",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       },
@@ -3411,42 +3251,13 @@
       }
     },
     "node_modules/@react-aria/utils": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.18.0.tgz",
-      "integrity": "sha512-eLs0ExzXx/D3P9qe6ophJ87ZFcI1oRTyRa51M59pCad7grrpk0gWcYrBjMwcR457YWOQQWCeLuq8QJl2QxCW6Q==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.24.1.tgz",
+      "integrity": "sha512-O3s9qhPMd6n42x9sKeJ3lhu5V1Tlnzhu6Yk8QOvDuXf7UGuUjXf9mzfHJt1dYzID4l9Fwm8toczBzPM9t0jc8Q==",
       "dependencies": {
-        "@react-aria/ssr": "^3.7.0",
-        "@react-stately/utils": "^3.7.0",
-        "@react-types/shared": "^3.18.1",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/visually-hidden": {
-      "version": "3.8.11",
-      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.11.tgz",
-      "integrity": "sha512-1JFruyAatoKnC18qrix8Q1gyUNlizWZvYdPADgB5btakMy0PEGTWPmFRK5gFsO+N0CZLCFTCip0dkUv6rrp31w==",
-      "dependencies": {
-        "@react-aria/interactions": "^3.21.2",
-        "@react-aria/utils": "^3.24.0",
-        "@react-types/shared": "^3.23.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/visually-hidden/node_modules/@react-aria/utils": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.24.0.tgz",
-      "integrity": "sha512-JAxkPhK5fCvFVNY2YG3TW3m1nTzwRcbz7iyTSkUzLFat4N4LZ7Kzh7NMHsgeE/oMOxd8zLY+XsUxMu/E/2GujA==",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.3",
-        "@react-stately/utils": "^3.10.0",
-        "@react-types/shared": "^3.23.0",
+        "@react-aria/ssr": "^3.9.4",
+        "@react-stately/utils": "^3.10.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0",
         "clsx": "^2.0.0"
       },
@@ -3454,35 +3265,14 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
-    "node_modules/@react-aria/visually-hidden/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@react-stately/collections": {
-      "version": "3.10.6",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.10.6.tgz",
-      "integrity": "sha512-hb/yzxQnZaSRu43iR6ftkCJIqD4Qu5WUjl4ASBn2EGb9TmipA7bFnYVqSH4xFPCCTZ68Qxh95dOcxYBHlHeWZQ==",
+    "node_modules/@react-aria/visually-hidden": {
+      "version": "3.8.12",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.12.tgz",
+      "integrity": "sha512-Bawm+2Cmw3Xrlr7ARzl2RLtKh0lNUdJ0eNqzWcyx4c0VHUAWtThmH5l+HRqFUGzzutFZVo89SAy40BAbd0gjVw==",
       "dependencies": {
-        "@react-types/shared": "^3.23.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/menu": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.5.3.tgz",
-      "integrity": "sha512-RFgwVD/4BgTtJkexi1WaHpAEkQWZPvpyri0LQUgXWVqBf9PpjB8wigF3XBLMDNkL+YXE0QtzQZBNS1nJECf7rg==",
-      "dependencies": {
-        "@react-stately/overlays": "^3.6.0",
-        "@react-stately/utils": "^3.7.0",
-        "@react-types/menu": "^3.9.2",
-        "@react-types/shared": "^3.18.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -3490,54 +3280,12 @@
       }
     },
     "node_modules/@react-stately/overlays": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.6.tgz",
-      "integrity": "sha512-NvzQXh4zYGZuUmZH5d3NmEDNr8r1hfub2s5w7WOeIG35xqIzoKGdFZ7LLWrie+4nxPmM+ckdfqOQ9pBZFNJypQ==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.7.tgz",
+      "integrity": "sha512-6zp8v/iNUm6YQap0loaFx6PlvN8C0DgWHNlrlzMtMmNuvjhjR0wYXVaTfNoUZBWj25tlDM81ukXOjpRXg9rLrw==",
       "dependencies": {
-        "@react-stately/utils": "^3.10.0",
-        "@react-types/overlays": "^3.8.6",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/selection": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.15.0.tgz",
-      "integrity": "sha512-OtypXNtvRWLmpkaktluzCYEXKXAON16WIJv2mZ4cae3H0UVfWaFL9sD+ST9nj7UqYNTDXECug5ziIY+YKd7zvA==",
-      "dependencies": {
-        "@react-stately/collections": "^3.10.6",
-        "@react-stately/utils": "^3.10.0",
-        "@react-types/shared": "^3.23.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/toggle": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.7.3.tgz",
-      "integrity": "sha512-4jW6wxTu7Gkq6/2mZWqtJoQ6ff27Cl6lnVMEXXM+M8HwK/3zHoMZhVz8EApwgOsRByxDQ76PNSGm3xKZAcqZNw==",
-      "dependencies": {
-        "@react-stately/utils": "^3.10.0",
-        "@react-types/checkbox": "^3.8.0",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/tree": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.8.0.tgz",
-      "integrity": "sha512-7bfbCLjG8BTiWuo9GBE1A375PPI4S9r/rMtKQGLQvYAObgJb7C8P3svA9WKfryvl7M5iqaYrOVA0uzNSmeCNQQ==",
-      "dependencies": {
-        "@react-stately/collections": "^3.10.6",
-        "@react-stately/selection": "^3.15.0",
-        "@react-stately/utils": "^3.10.0",
-        "@react-types/shared": "^3.23.0",
+        "@react-stately/utils": "^3.10.1",
+        "@react-types/overlays": "^3.8.7",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -3545,9 +3293,9 @@
       }
     },
     "node_modules/@react-stately/utils": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.0.tgz",
-      "integrity": "sha512-nji2i9fTYg65ZWx/3r11zR1F2tGya+mBubRCbMTwHyRnsSLFZaeq/W6lmrOyIy1uMJKBNKLJpqfmpT4x7rw6pg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.1.tgz",
+      "integrity": "sha512-VS/EHRyicef25zDZcM/ClpzYMC5i2YGN6uegOeQawmgfGjb02yaCX0F0zR69Pod9m2Hr3wunTbtpgVXvYbZItg==",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       },
@@ -3556,66 +3304,43 @@
       }
     },
     "node_modules/@react-types/button": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.9.3.tgz",
-      "integrity": "sha512-YHlSeH85FhasJXOmkY4x+6If74ZpUh88C2fMlw0HUA/Bq/KGckUoriV8cnMqSnB1OwPqi8dpBZGfFVj6f6lh9A==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.9.4.tgz",
+      "integrity": "sha512-raeQBJUxBp0axNF74TXB8/H50GY8Q3eV6cEKMbZFP1+Dzr09Ngv0tJBeW0ewAxAguNH5DRoMUAUGIXtSXskVdA==",
       "dependencies": {
-        "@react-types/shared": "^3.23.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/checkbox": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.8.0.tgz",
-      "integrity": "sha512-IBJ2bAsb3xoXaL+f0pwfRLDvRkhxfcX/q4NRJ2oT9jeHLU+j6svgK1Dqk8IGmY+vw1ltKbbMlIVeVonKQ3fgHw==",
-      "dependencies": {
-        "@react-types/shared": "^3.23.0"
+        "@react-types/shared": "^3.23.1"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
     "node_modules/@react-types/dialog": {
-      "version": "3.5.9",
-      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.9.tgz",
-      "integrity": "sha512-8r9P1b1gq/cUv2bTPPNL3IFVEj9R5sIPACoSXznXkpXxh5FLU6yUPHDeQjvmM50q7KlEOgrPYhGl5pW525kLww==",
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.10.tgz",
+      "integrity": "sha512-S9ga+edOLNLZw7/zVOnZdT5T40etpzUYBXEKdFPbxyPYnERvRxJAsC1/ASuBU9fQAXMRgLZzADWV+wJoGS/X9g==",
       "dependencies": {
-        "@react-types/overlays": "^3.8.6",
-        "@react-types/shared": "^3.23.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/menu": {
-      "version": "3.9.8",
-      "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.9.8.tgz",
-      "integrity": "sha512-nkRCsfD3NXsJOv6mAnXCFyH2eGOFsmOOJOBQeOl9dj7BcdX9dcqp2PzUWPl33GrY9rYcXiRx4wsbUoqO1KVU4g==",
-      "dependencies": {
-        "@react-types/overlays": "^3.8.6",
-        "@react-types/shared": "^3.23.0"
+        "@react-types/overlays": "^3.8.7",
+        "@react-types/shared": "^3.23.1"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
     "node_modules/@react-types/overlays": {
-      "version": "3.8.6",
-      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.6.tgz",
-      "integrity": "sha512-7xBuroYqwADppt7IRGfM8lbxVwlZrhMtTzeIdUot595cqFdRlpd/XAo2sRnEeIjYW9OSI8I5v4kt3AG7bdCQlg==",
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.7.tgz",
+      "integrity": "sha512-zCOYvI4at2DkhVpviIClJ7bRrLXYhSg3Z3v9xymuPH3mkiuuP/dm8mUCtkyY4UhVeUTHmrQh1bzaOP00A+SSQA==",
       "dependencies": {
-        "@react-types/shared": "^3.23.0"
+        "@react-types/shared": "^3.23.1"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
     "node_modules/@react-types/shared": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.23.0.tgz",
-      "integrity": "sha512-GQm/iPiii3ikcaMNR4WdVkJ4w0mKtV3mLqeSfSqzdqbPr6vONkqXbh3RhPlPmAJs1b4QHnexd/wZQP3U9DHOwQ==",
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.23.1.tgz",
+      "integrity": "sha512-5d+3HbFDxGZjhbMBeFHRQhexMFt4pUce3okyRtUVKbbedQFUrtXSBg9VszgF2RTeQDKDkMCIQDtz5ccP/Lk1gw==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
@@ -4451,9 +4176,9 @@
       "dev": true
     },
     "node_modules/@types/string-hash": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/string-hash/-/string-hash-1.1.1.tgz",
-      "integrity": "sha512-ijt3zdHi2DmZxQpQTmozXszzDo78V4R3EdvX0jFMfnMH2ZzQSmCbaWOMPGXFUYSzSIdStv78HDjg32m5dxc+tA=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha512-p6skq756fJWiA59g2Uss+cMl6tpoDGuCBuxG0SI1t0NwJmYOU66LAMS6QiCgu7cUh3/hYCaMl5phcCW1JP5wOA=="
     },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.8",
@@ -5841,9 +5566,9 @@
       "dev": true
     },
     "node_modules/classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -5924,9 +5649,9 @@
       }
     },
     "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
       }
@@ -6300,9 +6025,9 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/d3": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.8.5.tgz",
-      "integrity": "sha512-JgoahDG51ncUfJu6wX/1vWQEqOflgXyl4MaHqlcSruTez7yhaRKR9i8VjjcQGeS2en/jnFivXuaIMnseMMt0XA==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
       "dependencies": {
         "d3-array": "3",
         "d3-axis": "3",
@@ -6735,18 +6460,12 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -6965,9 +6684,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.2.tgz",
-      "integrity": "sha512-5vSyvxRAb45EoWwAktUT3AYqAwXK4FL7si22Cgj46U6ICsj/YJczCN+Bk7WNABIQmpWRymGfslMhrRUZkQNnqA=="
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.4.tgz",
+      "integrity": "sha512-2gnshi6OshmuKil8rMZuQCGiUF3cUxHY3NGDzUAdUx/NPEe5DVnO8BDoAQouvgwnx0R/+a6jUn36Z0FSdq8vww=="
     },
     "node_modules/earcut": {
       "version": "2.2.4",
@@ -8837,14 +8556,14 @@
       }
     },
     "node_modules/hyphenate-style-name": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.5.tgz",
+      "integrity": "sha512-fedL7PRwmeVkgyhu9hLeTBaI6wcGk7JGJswdaRsa5aUbkXI1kr1xZwTPBtaYPpwf56878iDek6VbVnuWMebJmw=="
     },
     "node_modules/i18next": {
-      "version": "22.5.1",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-22.5.1.tgz",
-      "integrity": "sha512-8TGPgM3pAD+VRsMtUMNknRz3kzqwp/gPALrWMsDnmC1mKqJwpWyooQRLMcbTwq8z8YwSmuj+ZYvc+xCuEpkssA==",
+      "version": "23.11.5",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.5.tgz",
+      "integrity": "sha512-41pvpVbW9rhZPk5xjCX2TPJi2861LEig/YRhUkY+1FQ2IQPS0bKUDYnEqY8XPPbB48h1uIwLnP9iiEfuSl20CA==",
       "funding": [
         {
           "type": "individual",
@@ -8860,7 +8579,7 @@
         }
       ],
       "dependencies": {
-        "@babel/runtime": "^7.20.6"
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/i18next-browser-languagedetector": {
@@ -8935,9 +8654,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.1.tgz",
-      "integrity": "sha512-lj9cnmB/kVS0QHsJnYKD1uo3o39nrbKxszjnqS9Fr6NB7bZzW45U6WSGBPKXDL/CvDKqDNPA4r3DoDQ8GTxo2A=="
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
+      "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -9048,13 +8767,13 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "10.5.12",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.12.tgz",
-      "integrity": "sha512-izl0uxhy/melhw8gP2r8pGiVieviZmM4v5Oqx3c1/R7g9cwER2smmGfSjcIsp8Y3Q53bfciL/gkxacJRx/dUvg==",
+      "version": "10.5.14",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.14.tgz",
+      "integrity": "sha512-IjC6sI0X7YRjjyVH9aUgdftcmZK7WXdHeil4KwbjDnRWjnVitKpAx3rr6t6di1joFp5188VqKcobOPA6mCLG/w==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
+        "@formatjs/ecma402-abstract": "2.0.0",
         "@formatjs/fast-memoize": "2.2.0",
-        "@formatjs/icu-messageformat-parser": "2.7.6",
+        "@formatjs/icu-messageformat-parser": "2.7.8",
         "tslib": "^2.4.0"
       }
     },
@@ -12363,9 +12082,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.0.tgz",
-      "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
     "node_modules/js-cookie": {
       "version": "2.2.1",
@@ -12756,9 +12475,9 @@
       "integrity": "sha512-X1dtuTuH2D1MRMuductMZCLV/fy9EoIgqW/lmu8vQSAhEatx/tdFebkYT3TVhdTwqFDHbLEgQBD3IKA4KI7aoQ=="
     },
     "node_modules/marked": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.1.tgz",
-      "integrity": "sha512-bTmmGdEINWmOMDjnPWDxGPQ4qkDLeYorpYbEtFOXzOruTwUE671q4Guiuchn4N8h/v6NGd7916kXsm3Iz4iUSg==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -12767,11 +12486,11 @@
       }
     },
     "node_modules/marked-mangle": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/marked-mangle/-/marked-mangle-1.1.0.tgz",
-      "integrity": "sha512-ed2W2gMB2HIBaYasBZveMFJfDRTL2OFycr0GgUSPcBSNl5dX+1r6lHG6u1eFXw7kej2hBTWa1m6YZqcfn4Coxw==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/marked-mangle/-/marked-mangle-1.1.7.tgz",
+      "integrity": "sha512-bLsXKovJEEs/Dl++TBPmjX8ALFmrH5G0doTs+BdDOloBKWYRf3acyJghce78SnwInDkNPJ6crubr4MnFG7urOA==",
       "peerDependencies": {
-        "marked": "^4 || ^5"
+        "marked": ">=4 <13"
       }
     },
     "node_modules/mdn-data": {
@@ -12933,17 +12652,17 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.43",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
-      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
       "dependencies": {
         "moment": "^2.29.4"
       },
@@ -12952,9 +12671,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.0.tgz",
-      "integrity": "sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ=="
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
+      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -12979,11 +12698,6 @@
         "react": "*",
         "react-dom": "*"
       }
-    },
-    "node_modules/nano-css/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/nano-css/node_modules/stylis": {
       "version": "4.3.2",
@@ -14002,14 +13716,14 @@
       }
     },
     "node_modules/rc-cascader": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.20.0.tgz",
-      "integrity": "sha512-lkT9EEwOcYdjZ/jvhLoXGzprK1sijT3/Tp4BLxQQcHDZkkOzzwYQC9HgmKoJz0K7CukMfgvO9KqHeBdgE+pELw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.25.0.tgz",
+      "integrity": "sha512-mBY6/CykOvzAYnIye0rpt5JkMAXJaX8zZawOwSndbKuFakYE+leqBQWIZoN9HIgAptPpTi2Aty3RvbaBmk8SKQ==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "array-tree-filter": "^2.1.0",
         "classnames": "^2.3.1",
-        "rc-select": "~14.10.0",
+        "rc-select": "~14.13.0",
         "rc-tree": "~5.8.1",
         "rc-util": "^5.37.0"
       },
@@ -14019,15 +13733,15 @@
       }
     },
     "node_modules/rc-drawer": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-6.5.2.tgz",
-      "integrity": "sha512-QckxAnQNdhh4vtmKN0ZwDf3iakO83W9eZcSKWYYTDv4qcD2fHhRAZJJ/OE6v2ZlQ2kSqCJX5gYssF4HJFvsEPQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-7.1.0.tgz",
+      "integrity": "sha512-nBE1rF5iZvpavoyqhSSz2mk/yANltA7g3aF0U45xkx381n3we/RKs9cJfNKp9mSWCedOKWt9FLEwZDaAaOGn2w==",
       "dependencies": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.23.9",
         "@rc-component/portal": "^1.1.1",
         "classnames": "^2.2.6",
         "rc-motion": "^2.6.1",
-        "rc-util": "^5.36.0"
+        "rc-util": "^5.38.1"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -14035,13 +13749,13 @@
       }
     },
     "node_modules/rc-motion": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.0.tgz",
-      "integrity": "sha512-XIU2+xLkdIr1/h6ohPZXyPBMvOmuyFZQ/T0xnawz+Rh+gh4FINcnZmMT5UTIj6hgI0VLDjTaPeRd+smJeSPqiQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.1.tgz",
+      "integrity": "sha512-QD4bUqByjVQs7PhUT1d4bNxvtTcK9ETwtg7psbDfo6TmYalH/1hhjj4r2hbhW7g5OOEqYHhfwfj4noIvuOVRtQ==",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
-        "rc-util": "^5.21.0"
+        "rc-util": "^5.39.3"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -14079,12 +13793,12 @@
       }
     },
     "node_modules/rc-select": {
-      "version": "14.10.0",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.10.0.tgz",
-      "integrity": "sha512-TsIJTYafTTapCA32LLNpx/AD6ntepR1TG8jEVx35NiAAWCPymhUfuca8kRcUNd3WIGVMDcMKn9kkphoxEz+6Ag==",
+      "version": "14.13.4",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.13.4.tgz",
+      "integrity": "sha512-nXFsS53RxCP6ePeKhOj3gvgdNpTqdQnNKhipGrV/z+pB3Md5heGfV72YX5Wfb1A7Ca1QkbVTPFLJh+A8WYFOSA==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
-        "@rc-component/trigger": "^1.5.0",
+        "@rc-component/trigger": "^2.1.1",
         "classnames": "2.x",
         "rc-motion": "^2.0.1",
         "rc-overflow": "^1.3.1",
@@ -14100,13 +13814,13 @@
       }
     },
     "node_modules/rc-slider": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-10.3.1.tgz",
-      "integrity": "sha512-XszsZLkbjcG9ogQy/zUC0n2kndoKUAnY/Vnk1Go5Gx+JJQBz0Tl15d5IfSiglwBUZPS9vsUJZkfCmkIZSqWbcA==",
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-10.6.2.tgz",
+      "integrity": "sha512-FjkoFjyvUQWcBo1F3RgSglky3ar0+qHLM41PlFVYB4Bj3RD8E/Mv7kqMouLFBU+3aFglMzzctAIWRwajEuueSw==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
-        "rc-util": "^5.27.0"
+        "rc-util": "^5.36.0"
       },
       "engines": {
         "node": ">=8.x"
@@ -14130,12 +13844,12 @@
       }
     },
     "node_modules/rc-tooltip": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.1.1.tgz",
-      "integrity": "sha512-YoxL0Ev4htsX37qgN23eKr0L5PIRpZaLVL9GX6aJ4x6UEnwgXZYUNCAEHfKlKT3eD1felDq3ob4+Cn9lprLDBw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.2.0.tgz",
+      "integrity": "sha512-iS/3iOAvtDh9GIx1ulY7EFUXUtktFccNLsARo3NPgLf0QW9oT0w3dA9cYWlhqAKmD+uriEwdWz1kH0Qs4zk2Aw==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
-        "@rc-component/trigger": "^1.17.0",
+        "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -14144,9 +13858,9 @@
       }
     },
     "node_modules/rc-tree": {
-      "version": "5.8.5",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.8.5.tgz",
-      "integrity": "sha512-PRfcZtVDNkR7oh26RuNe1hpw11c1wfgzwmPFL0lnxGnYefe9lDAO6cg5wJKIAwyXFVt5zHgpjYmaz0CPy1ZtKg==",
+      "version": "5.8.7",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.8.7.tgz",
+      "integrity": "sha512-cpsIQZ4nNYwpj6cqPRt52e/69URuNdgQF9wZ10InmEf8W3+i0A41OVmZWwHuX9gegQSqj+DPmaDkZFKQZ+ZV1w==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -14189,9 +13903,9 @@
       }
     },
     "node_modules/rc-util": {
-      "version": "5.39.3",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.39.3.tgz",
-      "integrity": "sha512-j9wOELkLQ8gC/NkUg3qg9mHZcJf+5mYYv40JrDHqnaf8VSycji4pCf7kJ5fdTXQPDIF0vr5zpb/T2HdrMs9rWA==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.41.0.tgz",
+      "integrity": "sha512-xtlCim9RpmVv0Ar2Nnc3WfJCxjQkTf3xHPWoFdjp1fSs2NirQwqiQrfqdU9HUe0kdfb168M/T8Dq0IaX50xeKg==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "react-is": "^18.2.0"
@@ -14207,9 +13921,9 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/rc-virtual-list": {
-      "version": "3.11.5",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.11.5.tgz",
-      "integrity": "sha512-iZRW99m5jAxtwKNPLwUrPryurcnKpXBdTyhuBp6ythf7kg/otKO5cCiIvL55GQwU0QGSlouQS0tnkciRMJUwRQ==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.14.2.tgz",
+      "integrity": "sha512-rA+W5xryhklJAcmswNyuKB3ZGeB855io+yOFQK5u/RXhjdshGblfKpNkQr4/9fBhZns0+uiL/0/s6IP2krtSmg==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "classnames": "^2.2.6",
@@ -14254,15 +13968,15 @@
       }
     },
     "node_modules/react-calendar": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-4.6.0.tgz",
-      "integrity": "sha512-GJ6ZipKMQmlK666t+0hgmecu6WHydEnMWJjKdEkUxW6F471hiM5DkbWXkfr8wlAg9tc9feNCBhXw3SqsPOm01A==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-4.8.0.tgz",
+      "integrity": "sha512-qFgwo+p58sgv1QYMI1oGNaop90eJVKuHTZ3ZgBfrrpUb+9cAexxsKat0sAszgsizPMVo7vOXedV7Lqa0GQGMvA==",
       "dependencies": {
         "@wojtekmaj/date-utils": "^1.1.3",
         "clsx": "^2.0.0",
         "get-user-locale": "^2.2.1",
         "prop-types": "^15.6.0",
-        "tiny-warning": "^1.0.0"
+        "warning": "^4.0.0"
       },
       "funding": {
         "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
@@ -14276,14 +13990,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-calendar/node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/react-colorful": {
@@ -14337,11 +14043,6 @@
         "react": ">= 16.8 || 18.0.0"
       }
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
-    },
     "node_modules/react-from-dom": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/react-from-dom/-/react-from-dom-0.6.2.tgz",
@@ -14369,9 +14070,9 @@
       "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
     },
     "node_modules/react-hook-form": {
-      "version": "7.51.4",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.4.tgz",
-      "integrity": "sha512-V14i8SEkh+V1gs6YtD0hdHYnoL4tp/HX/A45wWQN15CYr9bFRmmRdYStSO5L65lCCZRF+kYiSKhm9alqbcdiVA==",
+      "version": "7.51.5",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.5.tgz",
+      "integrity": "sha512-J2ILT5gWx1XUIJRETiA7M19iXHlG74+6O3KApzvqB/w8S5NQR7AbU8HVZrMALdmDgWpRPYiZJl0zx8Z4L2mP6Q==",
       "engines": {
         "node": ">=12.22.0"
       },
@@ -14384,15 +14085,15 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-12.3.1.tgz",
-      "integrity": "sha512-5v8E2XjZDFzK7K87eSwC7AJcAkcLt5xYZ4+yTPDAW1i7C93oOY1dnr4BaQM7un4Hm+GmghuiPvevWwlca5PwDA==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.1.2.tgz",
+      "integrity": "sha512-FSIcJy6oauJbGEXfhUgVeLzvWBhIBIS+/9c6Lj4niwKZyGaGb4V4vUbATXSlsHJDXXB+ociNxqFNiFuV1gmoqg==",
       "dependencies": {
-        "@babel/runtime": "^7.20.6",
+        "@babel/runtime": "^7.23.9",
         "html-parse-stringify": "^3.0.1"
       },
       "peerDependencies": {
-        "i18next": ">= 19.0.0",
+        "i18next": ">= 23.2.3",
         "react": ">= 16.8.0"
       },
       "peerDependenciesMeta": {
@@ -14438,25 +14139,11 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-loading-skeleton": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.3.1.tgz",
-      "integrity": "sha512-NilqqwMh2v9omN7LteiDloEVpFyMIa0VGqF+ukqp0ncVlYu1sKYbYGX9JEl+GtOT9TKsh04zCHAbavnQ2USldA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.4.0.tgz",
+      "integrity": "sha512-1oJEBc9+wn7BbkQQk7YodlYEIjgeR+GrRjD+QXkVjwZN7LGIcAFHrx4NhT7UHGBxNY1+zax3c+Fo6XQM4R7CgA==",
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/react-popper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
-      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
-      "dependencies": {
-        "react-fast-compare": "^3.0.1",
-        "warning": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@popperjs/core": "^2.0.0",
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-redux": {
@@ -14525,9 +14212,9 @@
       }
     },
     "node_modules/react-select": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.4.tgz",
-      "integrity": "sha512-NhuE56X+p9QDFh4BgeygHFIvJJszO1i1KSkg/JPcIJrbovyRtI+GuOEa4XzFCEpZRAEoEI8u/cAHK+jG/PgUzQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.8.0.tgz",
+      "integrity": "sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -14586,9 +14273,9 @@
       }
     },
     "node_modules/react-use": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.4.0.tgz",
-      "integrity": "sha512-TgbNTCA33Wl7xzIJegn1HndB4qTS9u03QUwyNycUnXaweZkE4Kq2SB+Yoxx8qbshkZGYBDvUXbXWRUmQDcZZ/Q==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.5.0.tgz",
+      "integrity": "sha512-PbfwSPMwp/hoL847rLnm/qkjg3sTRCvn6YhUZiHaUa3FA6/aNoFX79ul5Xt70O1rK+9GxSVqkY0eTwMdsR/bWg==",
       "dependencies": {
         "@types/js-cookie": "^2.2.6",
         "@xobotyi/scrollbar-width": "^1.9.5",
@@ -14596,7 +14283,7 @@
         "fast-deep-equal": "^3.1.3",
         "fast-shallow-equal": "^1.0.0",
         "js-cookie": "^2.2.1",
-        "nano-css": "^5.3.1",
+        "nano-css": "^5.6.1",
         "react-universal-interface": "^0.6.2",
         "resize-observer-polyfill": "^1.5.1",
         "screenfull": "^5.1.0",
@@ -14606,14 +14293,14 @@
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0  || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0  || ^17.0.0 || ^18.0.0"
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/react-window": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.9.tgz",
-      "integrity": "sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==",
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz",
+      "integrity": "sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "memoize-one": ">=3.1.1 <6"
@@ -15756,16 +15443,6 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
-    "node_modules/systemjs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.14.2.tgz",
-      "integrity": "sha512-1TlOwvKWdXxAY9vba+huLu99zrQURDWA8pUTYsRIYDZYQbGyK+pyEP4h4dlySsqo7ozyJBmYD20F+iUHhAltEg=="
-    },
-    "node_modules/systemjs-cjs-extra": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/systemjs-cjs-extra/-/systemjs-cjs-extra-0.2.0.tgz",
-      "integrity": "sha512-0dB6UkUNgXJ+GKt3OMONQmQV+stZPuy+0o5Bj4nP1YRtbCNtLg01sca3mSyOiBKAnqs5cjx7mTxwzomzsOFJnA=="
-    },
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
@@ -16419,9 +16096,9 @@
       }
     },
     "node_modules/uplot": {
-      "version": "1.6.28",
-      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.28.tgz",
-      "integrity": "sha512-6AQ/Hu2ZvwF1P6PtIELdWKFml8Vvf3PUqrkVndL4A1+s/0loHwXfsk3yMwy4WGkRAt0MAMpf0uKLa9h0Yt3miw=="
+      "version": "1.6.30",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.30.tgz",
+      "integrity": "sha512-48oVVRALM/128ttW19F2a2xobc2WfGdJ0VJFX00099CfqbCTuML7L2OrTKxNzeFP34eo1+yJbqFSoFAp2u28/Q=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -16470,9 +16147,13 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/examples/app-with-extension-point/package.json
+++ b/examples/app-with-extension-point/package.json
@@ -61,14 +61,14 @@
   },
   "dependencies": {
     "@emotion/css": "11.10.6",
-    "@grafana/data": "10.3.3",
-    "@grafana/runtime": "10.3.3",
-    "@grafana/ui": "10.3.3",
+    "@grafana/data": "11.1.0-179609",
+    "@grafana/runtime": "11.1.0-179609",
+    "@grafana/ui": "11.1.0-179609",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "^5.2.0",
     "tslib": "2.5.3",
-    "@grafana/schema": "10.3.3",
+    "@grafana/schema": "11.0.0",
     "rxjs": "7.8.1"
   },
   "packageManager": "npm@9.3.1"

--- a/examples/app-with-extension-point/src/components/App/App.tsx
+++ b/examples/app-with-extension-point/src/components/App/App.tsx
@@ -1,31 +1,28 @@
 import React from 'react';
-import { AppRootProps } from '@grafana/data';
-import { HorizontalGroup } from '@grafana/ui';
+import { HorizontalGroup, LoadingPlaceholder } from '@grafana/ui';
 import { ActionButton } from 'components/ActionButton';
-import { getPluginExtensions } from '@grafana/runtime';
+import { usePluginExtensions } from '@grafana/runtime';
 import { testIds } from 'components/testIds';
 
 type AppExtensionContext = {};
 
-export class App extends React.PureComponent<AppRootProps> {
-  render() {
-    const extensionPointId = 'plugins/myorg-extensionpoint-app/actions';
-    const context: AppExtensionContext = {};
+export const App = () => {
+  const extensionPointId = 'plugins/myorg-extensionpoint-app/actions';
+  const context: AppExtensionContext = {};
+  const { isLoading, extensions } = usePluginExtensions({
+    extensionPointId,
+    context,
+  });
 
-    const { extensions } = getPluginExtensions({
-      extensionPointId,
-      context,
-    });
-
-    return (
-      <div data-testid={testIds.container} style={{ marginTop: '5%' }}>
-        <HorizontalGroup align="flex-start" justify="center">
-          <HorizontalGroup>
-            <span>Hello Grafana! These are the actions you can trigger from this plugin</span>
-            <ActionButton extensions={extensions} />
-          </HorizontalGroup>
+  return (
+    <div data-testid={testIds.container} style={{ marginTop: '5%' }}>
+      <HorizontalGroup align="flex-start" justify="center">
+        <HorizontalGroup>
+          <span>Hello Grafana! These are the actions you can trigger from this plugin</span>
+          {isLoading ? <LoadingPlaceholder text="Loading..." /> : <ActionButton extensions={extensions} />}
         </HorizontalGroup>
-      </div>
-    );
-  }
-}
+      </HorizontalGroup>
+    </div>
+  );
+};
+


### PR DESCRIPTION
### What changed?
Updated the example to use the `usePluginExtensions()` hook instead of the getter - as this is what we are suggesting to use now and we are moving away (deprecating) the getter.

**Note for the reviewer**
Unfortunately there is no public release yet where `@grafana/runtime` would contain the hooks (11.0.0 still doesn't have them), so I had to use a canary version of the package, and the `main` docker image tag, I am not sure how much this is a problem.

@sympatheticmoose for visibility.