### PR TITLE
Plugin.json: update schema reference URLs

### DIFF
--- a/examples/app-basic/src/plugin.json
+++ b/examples/app-basic/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "Basic App",
   "id": "myorg-basic-app",

--- a/examples/app-with-backend/src/plugin.json
+++ b/examples/app-with-backend/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "App With Backend",
   "id": "myorg-withbackend-app",

--- a/examples/app-with-dashboards/src/plugin.json
+++ b/examples/app-with-dashboards/src/plugin.json
@@ -1,12 +1,10 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "Basic App With Dashboards",
   "id": "myorg-dashboard-app",
   "info": {
-    "keywords": [
-      "app"
-    ],
+    "keywords": ["app"],
     "description": "A basic grafana app plugin with dashboards",
     "author": {
       "name": "Your name"

--- a/examples/app-with-extension-point/src/plugin.json
+++ b/examples/app-with-extension-point/src/plugin.json
@@ -1,13 +1,11 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "Extension Point App",
   "id": "myorg-extensionpoint-app",
   "preload": true,
   "info": {
-    "keywords": [
-      "app"
-    ],
+    "keywords": ["app"],
     "description": "Show case how to add an extension point to your plugin",
     "author": {
       "name": "Myorg"

--- a/examples/app-with-extension-point/src/plugins/myorg-a-app/plugin.json
+++ b/examples/app-with-extension-point/src/plugins/myorg-a-app/plugin.json
@@ -1,13 +1,11 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "A App",
   "id": "myorg-a-app",
   "preload": true,
   "info": {
-    "keywords": [
-      "app"
-    ],
+    "keywords": ["app"],
     "description": "Will extend root app with ui extensions",
     "author": {
       "name": "Myorg"

--- a/examples/app-with-extension-point/src/plugins/myorg-b-app/plugin.json
+++ b/examples/app-with-extension-point/src/plugins/myorg-b-app/plugin.json
@@ -1,13 +1,11 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "B App",
   "id": "myorg-b-app",
   "preload": true,
   "info": {
-    "keywords": [
-      "app"
-    ],
+    "keywords": ["app"],
     "description": "Will extend root app with ui extensions",
     "author": {
       "name": "Myorg"

--- a/examples/app-with-extensions/src/plugin.json
+++ b/examples/app-with-extensions/src/plugin.json
@@ -1,13 +1,11 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "Extensions App",
   "id": "myorg-extensions-app",
   "preload": true,
   "info": {
-    "keywords": [
-      "app"
-    ],
+    "keywords": ["app"],
     "description": "Example on how to extend grafana ui from a plugin",
     "author": {
       "name": "Myorg"

--- a/examples/app-with-scenes/src/plugin.json
+++ b/examples/app-with-scenes/src/plugin.json
@@ -1,14 +1,10 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "Scenes App Example",
   "id": "myorg-scenes-app",
   "info": {
-    "keywords": [
-      "basic",
-      "app",
-      "example"
-    ],
+    "keywords": ["basic", "app", "example"],
     "description": "A basic grafana app plugin",
     "author": {
       "name": "Your name"

--- a/examples/datasource-http-backend/src/plugin.json
+++ b/examples/datasource-http-backend/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
   "name": "Datasource Http Backend",
   "id": "grafana-datasourcehttpbackend-datasource",

--- a/examples/datasource-http/src/plugin.json
+++ b/examples/datasource-http/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
   "name": "HTTP",
   "id": "example-http-datasource",
@@ -10,9 +10,7 @@
       "name": "Grafana Labs",
       "url": "https://grafana.com"
     },
-    "keywords": [
-      "example"
-    ],
+    "keywords": ["example"],
     "logos": {
       "small": "img/logo.svg",
       "large": "img/logo.svg"

--- a/examples/datasource-logs/src/plugin.json
+++ b/examples/datasource-logs/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
   "name": "example-logs",
   "id": "grafana-logs-datasource",

--- a/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/src/plugin.json
+++ b/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
   "name": "Streaming Backend Example",
   "id": "example-websocket-datasource",

--- a/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/plugin.json
+++ b/examples/datasource-streaming-websocket/streaming-websocket-plugin/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
   "name": "Streaming websocket example",
   "id": "example-websocket-datasource",

--- a/examples/panel-basic/src/plugin.json
+++ b/examples/panel-basic/src/plugin.json
@@ -1,13 +1,10 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "panel",
   "name": "Basic Panel",
   "id": "basic-panel",
   "info": {
-    "keywords": [
-      "panel",
-      "example"
-    ],
+    "keywords": ["panel", "example"],
     "description": "Showcase how to build a basic panel plugin",
     "author": {
       "name": "Your Name"

--- a/examples/panel-datalinks/src/plugin.json
+++ b/examples/panel-datalinks/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "panel",
   "name": "Data links panel",
   "id": "myorg-datalinks-panel",

--- a/examples/panel-frame-select/src/plugin.json
+++ b/examples/panel-frame-select/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "panel",
   "name": "Example",
   "id": "example-frameselect-panel",


### PR DESCRIPTION
### What changed?

Updated the reference URLs to the plugin.json schema (it was pointing to the old one).
(I only updated the examples that are not going to be deleted by this PR: https://github.com/grafana/grafana-plugin-examples/pull/309)