### PR TITLE
Chore: App with scenes fix drill down page title when space is present in room name

### DIFF
--- a/examples/app-with-scenes/src/pages/WithDrilldown/WithDrilldown.tsx
+++ b/examples/app-with-scenes/src/pages/WithDrilldown/WithDrilldown.tsx
@@ -70,7 +70,7 @@ const getDrilldownsAppScene = () => {
 
               return new SceneAppPage({
                 url: prefixRoute(`${ROUTES.WithDrilldown}`) + `/room/${roomName}/temperature`,
-                title: `${roomName} overview`,
+                title: `${decodeURI(roomName)} overview`,
                 subTitle: 'This scene is a particular room drilldown. It implements two tabs to organise the data.',
                 getParentPage: () => parent,
                 getScene: () => {


### PR DESCRIPTION
This change is broken out from https://github.com/grafana/grafana-plugin-examples/pull/273

Before we were taking raw URI encoded string and presenting it to user making two word room names have a `%20` show up as a space. Now we decode the URI so it is human readable.

I noticed this while creating [this basic demo](https://drive.google.com/file/d/1C3PDt3an9rcKjJtGsTpOTyYGnmypogKi/view?usp=sharing) getting a scenes app up and running in a local Grafana instance.

Before
![Screenshot 2024-01-22 at 2 55 05 PM](https://github.com/grafana/scenes-app-template/assets/22381771/6fc5ece3-8907-4b3f-ad9e-e41109b615ab)


After
![Screenshot 2024-01-22 at 3 22 45 PM](https://github.com/grafana/scenes-app-template/assets/22381771/17d7c9ef-15e2-456e-b5f8-c4df601db0e9)

