### PR TITLE
Chore: Remove redundant cypress files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Some of the examples in this repository contain integration tests that make use 
 
 ### Testing against latest versions of Grafana
 
-The GitHub workflow `.github/workflows/integration-tests.yml` finds all plugin examples identified by the existence of `src/plugin.json`. For every example plugin build scripts will be run to confirm the plugins can be built against intended and canary NPM packages. Any example plugin that has a cypress directory defined will run the following:
+The GitHub workflow `.github/workflows/integration-tests.yml` finds all plugin examples identified by the existence of `src/plugin.json`. For every example plugin, build scripts will be run to confirm the plugins can be built against intended and canary NPM packages. Any example plugin that has a playwright.config.ts file will run the following:
 
 1. Build the plugin with the provided version of Grafana packages and test against the provided version of Grafana
    - _asserting the plugin works with its expected versions_

--- a/examples/app-with-backend/cypress.json
+++ b/examples/app-with-backend/cypress.json
@@ -1,9 +1,0 @@
-{
-    "video": false,
-    "videoCompression": false,
-    "screenshotOnRunFailure": true,
-    "reporter": "spec",
-    "retries": {
-        "runMode": 3
-    }
-}

--- a/examples/app-with-extension-point/cypress.json
+++ b/examples/app-with-extension-point/cypress.json
@@ -1,9 +1,0 @@
-{
-    "video": false,
-    "videoCompression": false,
-    "screenshotOnRunFailure": true,
-    "reporter": "spec",
-    "retries": {
-        "runMode": 3
-    }
-}

--- a/examples/app-with-extensions/cypress.json
+++ b/examples/app-with-extensions/cypress.json
@@ -1,9 +1,0 @@
-{
-    "video": false,
-    "videoCompression": false,
-    "screenshotOnRunFailure": true,
-    "reporter": "spec",
-    "retries": {
-        "runMode": 3
-    }
-}

--- a/examples/datasource-basic/cypress.json
+++ b/examples/datasource-basic/cypress.json
@@ -1,9 +1,0 @@
-{
-  "video": false,
-  "videoCompression": false,
-  "screenshotOnRunFailure": true,
-  "reporter": "spec",
-  "retries": {
-    "runMode": 3
-  }
-}

--- a/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/cypress.json
+++ b/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/cypress.json
@@ -1,3 +1,0 @@
-{
-  "video": false
-}

--- a/examples/panel-basic/cypress.json
+++ b/examples/panel-basic/cypress.json
@@ -1,9 +1,0 @@
-{
-    "video": false,
-    "videoCompression": false,
-    "screenshotOnRunFailure": true,
-    "reporter": "spec",
-    "retries": {
-        "runMode": 3
-    }
-}

--- a/examples/panel-datalinks/cypress.json
+++ b/examples/panel-datalinks/cypress.json
@@ -1,9 +1,0 @@
-{
-  "video": false,
-  "videoCompression": false,
-  "screenshotOnRunFailure": true,
-  "reporter": "spec",
-  "retries": {
-    "runMode": 3
-  }
-}


### PR DESCRIPTION
Noticed we still have some cypress related configs and blurb in the readme. This PR removes the config files and updates the integration test explanation in the repo readme.