### PR TITLE
Fix: Streaming Backend Websocket DS provisioning

### DIFF
--- a/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/provisioning/datasources/datasources.yml
+++ b/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/provisioning/datasources/datasources.yml
@@ -3,14 +3,11 @@ apiVersion: 1
 datasources:
   - name: Streaming websocket datasource
     type: example-websocket-backend-datasource
+    uid: PA8F7D06AF7AEED65
     access: proxy
     isDefault: true
     orgId: 1
     version: 1
     editable: true
-    url: 'ws://host.docker.internal:8080'
     jsonData:
-      path: '/resources'
-      defaultTimeField: 
-    secureJsonData: 
-      apiKey: 'api-key'
+      uri: 'ws://host.docker.internal:8080'

--- a/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/tests/configEditor.spec.ts
+++ b/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/tests/configEditor.spec.ts
@@ -1,12 +1,21 @@
 import { test, expect } from '@grafana/plugin-e2e';
-import { BasicDataSourceOptions, BasicSecureJsonData } from '../src/types';
+import { MyDataSourceOptions } from '../src/types';
+
+test('Provisioned data source with valid credentials should return a 200 status code', async ({
+  readProvisionedDataSource,
+  gotoDataSourceConfigPage,
+}) => {
+  const datasource = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+  const configPage = await gotoDataSourceConfigPage(datasource.uid);
+  await expect(configPage.saveAndTest()).toBeOK();
+});
 
 test('"Save & test" should be successful when configuration is valid', async ({
   createDataSourceConfigPage,
   readProvisionedDataSource,
   page,
 }) => {
-  const ds = await readProvisionedDataSource<BasicDataSourceOptions, BasicSecureJsonData>({
+  const ds = await readProvisionedDataSource<MyDataSourceOptions>({
     fileName: 'datasources.yml',
   });
   const configPage = await createDataSourceConfigPage({ type: ds.type });
@@ -20,7 +29,7 @@ test('"Save & test" should fail when configuration is invalid', async ({
   readProvisionedDataSource,
   page,
 }) => {
-  const ds = await readProvisionedDataSource<BasicDataSourceOptions, BasicSecureJsonData>({
+  const ds = await readProvisionedDataSource<MyDataSourceOptions>({
     fileName: 'datasources.yml',
   });
   const configPage = await createDataSourceConfigPage({ type: ds.type });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,1 @@
+// This file exists so opening the entire repo in VS Code doesn't show a warning about no tsconfig.json file


### PR DESCRIPTION
This PR fixes the datasource-streaming-backend-websocket example which wouldn't work out the box due to the provisioning file not having the jsondata populated.

I've added a e2e test to validate this works out the box as any one that wants to use this example to get started will hit a wall if the provisioning is broken.

I also added a tsconfig.json to the root so VSCode would stop complaining about it when opening the entire repo.