### PR TITLE
Chore: Fix flaky test for datasources

### DIFF
--- a/examples/datasource-http-backend/tests/configEditor.spec.ts
+++ b/examples/datasource-http-backend/tests/configEditor.spec.ts
@@ -11,7 +11,7 @@ test('"Save & test" should be successful when configuration is valid', async ({
   const configPage = await createDataSourceConfigPage({ type: ds.type });
   await page.getByTestId('data-testid Datasource HTTP settings url').fill('http://host.docker.internal:10000/metrics');
   await expect(configPage.saveAndTest()).toBeOK();
-  expect(configPage).toHaveAlert('success');
+  await expect(configPage).toHaveAlert('success');
 });
 
 test('"Save & test" should fail when configuration is invalid', async ({
@@ -23,5 +23,5 @@ test('"Save & test" should fail when configuration is invalid', async ({
   const configPage = await createDataSourceConfigPage({ type: ds.type });
   await page.getByTestId('data-testid Datasource HTTP settings url').fill('http://test.com/tests');
   await expect(configPage.saveAndTest()).not.toBeOK();
-  expect(configPage).toHaveAlert('error', { hasText: 'request error' });
+  await expect(configPage).toHaveAlert('error', { hasText: 'request error' });
 });

--- a/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/tests/configEditor.spec.ts
+++ b/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/tests/configEditor.spec.ts
@@ -21,7 +21,7 @@ test('"Save & test" should be successful when configuration is valid', async ({
   const configPage = await createDataSourceConfigPage({ type: ds.type });
   await page.getByTestId('uri-websocket-server').fill('ws://host.docker.internal:8080');
   await expect(configPage.saveAndTest()).toBeOK();
-  expect(configPage).toHaveAlert('success');
+  await expect(configPage).toHaveAlert('success');
 });
 
 test('"Save & test" should fail when configuration is invalid', async ({
@@ -35,5 +35,5 @@ test('"Save & test" should fail when configuration is invalid', async ({
   const configPage = await createDataSourceConfigPage({ type: ds.type });
   await page.getByTestId('uri-websocket-server').fill('test.com');
   await expect(configPage.saveAndTest()).not.toBeOK();
-  expect(configPage).toHaveAlert('error');
+  await expect(configPage).toHaveAlert('error');
 });


### PR DESCRIPTION
We  had a flaky test run probably because of a missing `await`. https://github.com/grafana/grafana-plugin-examples/actions/runs/9918499270/attempts/1

An issue for the incorrect types in the e2e package was also created https://github.com/grafana/plugin-tools/issues/1010