### PR TITLE
README: Disclaimer - Single organization limitation

### DIFF
--- a/examples/app-with-rbac/README.md
+++ b/examples/app-with-rbac/README.md
@@ -105,6 +105,10 @@ To do so, activate two additional features:
 - `externalServiceAccounts` - To obtain a managed service account to retrieve Grafana users' permissions.
 - `idForwarding` - To obtain an ID token that identify the requester (user or service account).
 
+**Warning:** The `externalServiceAccounts` feature currently **only supports single-organization deployments**.
+The plugin's service account is automatically created in the default organization (ID: `1`). This means the plugin can only access data and resources within that specific organization.
+**If your plugin needs to work with multiple organizations, this feature is not suitable.**
+
 In your `plugin.json`, add the `iam` section to get a service account token with the needed permissions:
 
 ```json

--- a/examples/app-with-service-account/README.md
+++ b/examples/app-with-service-account/README.md
@@ -4,6 +4,10 @@ This plugin is an example of how to integrate Service Account authentication int
 
 **Note:** This plugin requires Grafana 10.3 or later and the `externalServiceAccounts` feature toggle must be enabled. This is an experimental feature.
 
+**Warning:** This feature currently **only supports single-organization deployments**.
+The plugin's service account is automatically created in the default organization (ID: `1`). This means the plugin can only access data and resources within that specific organization.
+**If your plugin needs to work with multiple organizations, this feature is not suitable.**
+
 ## How to use
 
 This app allows you to create a service account in Grafana tailored to your plugin needs. Grafana will provide the plugin with a service account token that you can use to request the Grafana API.


### PR DESCRIPTION
This PR introduces a small addition to the README file to emphasize that the `externalServiceAccounts` feature does not support multiple organizations setups.