### PR TITLE
Docs: Reflect managed service accounts feature GA

### DIFF
--- a/examples/app-with-rbac/README.md
+++ b/examples/app-with-rbac/README.md
@@ -102,12 +102,18 @@ If your backend is exposing resources, you can also protect them behind an actio
 
 To do so, activate two additional features:
 
-- `externalServiceAccounts` - To obtain a managed service account to retrieve Grafana users' permissions.
-- `idForwarding` - To obtain an ID token that identify the requester (user or service account).
+1. **Managed Service Accounts:** This allows your plugin to obtain a dedicated service account for interacting with the Grafana API.
 
-**Warning:** The `externalServiceAccounts` feature currently **only supports single-organization deployments**.
-The plugin's service account is automatically created in the default organization (ID: `1`). This means the plugin can only access data and resources within that specific organization.
-**If your plugin needs to work with multiple organizations, this feature is not suitable.**
+   - Grafana versions **below 11.3.0**: Enable the `externalServiceAccounts` feature toggle.
+   - Grafana **11.3.0 and later**: Activate the `managed_service_accounts_enabled` configuration option in the [auth section](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#auth-section) of your Grafana configuration file.
+
+   **Warning:** The `externalServiceAccounts` feature currently **only supports single-organization deployments**.
+   The plugin's service account is automatically created in the default organization (ID: `1`). This means the plugin can only access data and resources within that specific organization.
+   **If your plugin needs to work with multiple organizations, this feature is not suitable.**
+
+2. **ID Token Forwarding:** This enables your plugin's backend to receive an ID token that identifies the requester (user or service account), allowing you to enforce access control.
+
+   - Enable the `idForwarding` feature toggle.
 
 In your `plugin.json`, add the `iam` section to get a service account token with the needed permissions:
 

--- a/examples/app-with-service-account/README.md
+++ b/examples/app-with-service-account/README.md
@@ -2,7 +2,10 @@
 
 This plugin is an example of how to integrate Service Account authentication into a Grafana plugin.
 
-**Note:** This plugin requires Grafana 10.3 or later and the `externalServiceAccounts` feature toggle must be enabled. This is an experimental feature.
+**Note:** This plugin requires Grafana 10.3 or later and the `Managed Service Accounts` feature must be enabled:
+
+- Grafana versions **below 11.3.0**: Enable the `externalServiceAccounts` feature toggle.
+- Grafana **11.3.0 and later**: Activate the `managed_service_accounts_enabled` configuration option in the [auth section](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#auth-section) of your Grafana configuration file.
 
 **Warning:** This feature currently **only supports single-organization deployments**.
 The plugin's service account is automatically created in the default organization (ID: `1`). This means the plugin can only access data and resources within that specific organization.


### PR DESCRIPTION
This PR documents the `managed_service_accounts_enabled` configuration option that is used in place of the externalServiceAccounts feature toggle starting with 11.3.0

Follow up to:
- https://github.com/grafana/grafana/pull/93384
- https://github.com/grafana/plugin-tools/pull/1142