### PR TITLE
App with extension point: Fix failing e2e test

### DIFF
--- a/examples/app-with-extension-point/src/components/ActionButton/ActionButton.tsx
+++ b/examples/app-with-extension-point/src/components/ActionButton/ActionButton.tsx
@@ -7,11 +7,11 @@ import { testIds } from 'components/testIds';
 import React, { ReactElement, useMemo, useState } from 'react';
 
 type Props = {
-  extensions: PluginExtension[];
+  links: PluginExtensionLink[];
 };
 
-export function ActionButton(props: Props): ReactElement {
-  const options = useExtensionsAsOptions(props.extensions);
+export function ActionButton({ links }: Props): ReactElement {
+  const options = useExtensionsAsOptions(links);
   const [extension, setExtension] = useState<PluginExtensionLink | undefined>();
 
   if (options.length === 0) {

--- a/examples/app-with-extension-point/src/components/App/App.tsx
+++ b/examples/app-with-extension-point/src/components/App/App.tsx
@@ -1,31 +1,21 @@
 import React from 'react';
-import { AppRootProps } from '@grafana/data';
 import { HorizontalGroup } from '@grafana/ui';
 import { ActionButton } from 'components/ActionButton';
-import { getPluginExtensions } from '@grafana/runtime';
+import { usePluginLinks } from '@grafana/runtime';
 import { testIds } from 'components/testIds';
 
-type AppExtensionContext = {};
+export const App = () => {
+  const extensionPointId = 'plugins/myorg-extensionpoint-app/actions';
+  const { links } = usePluginLinks({ extensionPointId });
 
-export class App extends React.PureComponent<AppRootProps> {
-  render() {
-    const extensionPointId = 'plugins/myorg-extensionpoint-app/actions';
-    const context: AppExtensionContext = {};
-
-    const { extensions } = getPluginExtensions({
-      extensionPointId,
-      context,
-    });
-
-    return (
-      <div data-testid={testIds.container} style={{ marginTop: '5%' }}>
-        <HorizontalGroup align="flex-start" justify="center">
-          <HorizontalGroup>
-            <span>Hello Grafana! These are the actions you can trigger from this plugin</span>
-            <ActionButton extensions={extensions} />
-          </HorizontalGroup>
+  return (
+    <div data-testid={testIds.container} style={{ marginTop: '5%' }}>
+      <HorizontalGroup align="flex-start" justify="center">
+        <HorizontalGroup>
+          <span>Hello Grafana! These are the actions you can trigger from this plugin</span>
+          <ActionButton links={links} />
         </HorizontalGroup>
-      </div>
-    );
-  }
-}
+      </HorizontalGroup>
+    </div>
+  );
+};

--- a/examples/app-with-extension-point/src/plugin.json
+++ b/examples/app-with-extension-point/src/plugin.json
@@ -33,5 +33,13 @@
   "dependencies": {
     "grafanaDependency": ">=10.3.3",
     "plugins": []
+  },
+  "extensions": {
+    "extensionPoints": [
+      {
+        "id": "plugins/myorg-extensionpoint-app/actions",
+        "title": "Foo"
+      }
+    ]
   }
 }

--- a/examples/app-with-extension-point/src/plugin.json
+++ b/examples/app-with-extension-point/src/plugin.json
@@ -31,7 +31,7 @@
     }
   ],
   "dependencies": {
-    "grafanaDependency": ">=10.3.3",
+    "grafanaDependency": ">=11.1.0",
     "plugins": []
   },
   "extensions": {

--- a/examples/app-with-extension-point/src/plugins/myorg-a-app/plugin.json
+++ b/examples/app-with-extension-point/src/plugins/myorg-a-app/plugin.json
@@ -29,7 +29,7 @@
     }
   ],
   "dependencies": {
-    "grafanaDependency": ">=10.3.3",
+    "grafanaDependency": ">=11.1.0",
     "plugins": []
   },
   "extensions": {

--- a/examples/app-with-extension-point/src/plugins/myorg-a-app/plugin.json
+++ b/examples/app-with-extension-point/src/plugins/myorg-a-app/plugin.json
@@ -5,9 +5,7 @@
   "id": "myorg-a-app",
   "preload": true,
   "info": {
-    "keywords": [
-      "app"
-    ],
+    "keywords": ["app"],
     "description": "Will extend root app with ui extensions",
     "author": {
       "name": "Myorg"
@@ -33,5 +31,14 @@
   "dependencies": {
     "grafanaDependency": ">=10.3.3",
     "plugins": []
+  },
+  "extensions": {
+    "addedLinks": [
+      {
+        "targets": ["plugins/myorg-extensionpoint-app/actions"],
+        "title": "Go to A",
+        "description": "Navigating to pluging A"
+      }
+    ]
   }
 }

--- a/examples/app-with-extension-point/src/plugins/myorg-b-app/plugin.json
+++ b/examples/app-with-extension-point/src/plugins/myorg-b-app/plugin.json
@@ -29,7 +29,7 @@
     }
   ],
   "dependencies": {
-    "grafanaDependency": ">=10.3.3",
+    "grafanaDependency": ">=11.1.0",
     "plugins": []
   },
   "extensions": {

--- a/examples/app-with-extension-point/src/plugins/myorg-b-app/plugin.json
+++ b/examples/app-with-extension-point/src/plugins/myorg-b-app/plugin.json
@@ -5,9 +5,7 @@
   "id": "myorg-b-app",
   "preload": true,
   "info": {
-    "keywords": [
-      "app"
-    ],
+    "keywords": ["app"],
     "description": "Will extend root app with ui extensions",
     "author": {
       "name": "Myorg"
@@ -33,5 +31,14 @@
   "dependencies": {
     "grafanaDependency": ">=10.3.3",
     "plugins": []
+  },
+  "extensions": {
+    "addedLinks": [
+      {
+        "title": "Open from B",
+        "description": "Open a modal from plugin B",
+        "targets": ["plugins/myorg-extensionpoint-app/actions"]
+      }
+    ]
   }
 }


### PR DESCRIPTION
This PR updates the app with extension point example to work with the latest canary version of Grafana by:

- including the extension info in the plugin.json so they can be registered.
- using the `usePluginLinks` hook to register the extension point so the app re-renders when the extensions are added to the registry.

