### PR TITLE
chore: bumping go version 1.22

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -92,7 +92,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "~1.21"
+          go-version: "~1.22"
           check-latest: true
           cache-dependency-path: ${{ matrix.pluginDir }}/go.sum
         if: steps.backend-check.outputs.MAGEFILE_EXISTS == 'true'

--- a/examples/app-with-backend/go.mod
+++ b/examples/app-with-backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/app-with-backend
 
-go 1.21
+go 1.22
 
 toolchain go1.22.1
 

--- a/examples/app-with-service-account/go.mod
+++ b/examples/app-with-service-account/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/app-with-service-account
 
-go 1.21
+go 1.22
 
 require github.com/grafana/grafana-plugin-sdk-go v0.252.0
 

--- a/examples/datasource-basic/go.mod
+++ b/examples/datasource-basic/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/basic-datasource
 
-go 1.21
+go 1.22
 
 toolchain go1.22.1
 

--- a/examples/datasource-http-backend/go.mod
+++ b/examples/datasource-http-backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/datasource-http-backend
 
-go 1.21
+go 1.22
 
 toolchain go1.22.1
 

--- a/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/go.mod
+++ b/examples/datasource-streaming-backend-websocket/streaming-backend-websocket-plugin/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/example-websocket-datasource
 
-go 1.21
+go 1.22
 
 toolchain go1.22.1
 


### PR DESCRIPTION
https://github.com/grafana/grafana-plugin-sdk-go/issues/1107

### Tests
Integration tests are passing.