### PR TITLE
Improve e2e test

### DIFF
--- a/examples/datasource-http-backend/tests/configEditor.spec.ts
+++ b/examples/datasource-http-backend/tests/configEditor.spec.ts
@@ -21,7 +21,7 @@ test('"Save & test" should fail when configuration is invalid', async ({
 }) => {
   const ds = await readProvisionedDataSource<MyDataSourceOptions, MySecureJsonData>({ fileName: 'datasources.yml' });
   const configPage = await createDataSourceConfigPage({ type: ds.type });
-  await page.getByTestId('data-testid Datasource HTTP settings url').fill('http://test.com/tests');
+  await page.getByTestId('data-testid Datasource HTTP settings url').fill('invalid url');
   await expect(configPage.saveAndTest()).not.toBeOK();
   await expect(configPage).toHaveAlert('error', { hasText: 'request error' });
 });


### PR DESCRIPTION
There's an e2e test where save and test is expected to fail in a datasource config page. However, the "bad url" that was provided actually exists. This PR changes the url so that it's invalid and therefore makes the test fail consistently. 