### PR TITLE
Fix url in e2e test

### DIFF
--- a/examples/datasource-http-backend/tests/configEditor.spec.ts
+++ b/examples/datasource-http-backend/tests/configEditor.spec.ts
@@ -21,7 +21,7 @@ test('"Save & test" should fail when configuration is invalid', async ({
 }) => {
   const ds = await readProvisionedDataSource<MyDataSourceOptions, MySecureJsonData>({ fileName: 'datasources.yml' });
   const configPage = await createDataSourceConfigPage({ type: ds.type });
-  await page.getByTestId('data-testid Datasource HTTP settings url').fill('invalid url');
+  await page.getByTestId('data-testid Datasource HTTP settings url').fill('invalid-url');
   await expect(configPage.saveAndTest()).not.toBeOK();
   await expect(configPage).toHaveAlert('error', { hasText: 'request error' });
 });


### PR DESCRIPTION
Accidentally merged a [PR](https://github.com/grafana/grafana-plugin-examples/pull/418) where the tests weren't passing. This PR should make sure the test works again.