### PR TITLE
Deploy Playwright reports to GH Pages 

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -188,7 +188,7 @@ jobs:
 
       - name: Expected - Upload e2e test summary
         uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@gh-pages
-        if: ${{ always() && !cancelled() }}
+        if: ${{ always() && steps.expected-version-tests.outcome == 'failure' }}
         with:
           report-dir: ${{ matrix.pluginDir }}/playwright-report
           grafana-version: ${{ env.EXPECTED_GRAFANA_VERSION }}
@@ -229,7 +229,7 @@ jobs:
 
       - name: Latest - Upload e2e test summary
         uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@gh-pages
-        if: ${{ always() && !cancelled() }}
+        if: ${{ always() && steps.latest-version-tests.outcome == 'failure' }}
         with:
           report-dir: ${{ matrix.pluginDir }}/playwright-report
           grafana-version: latest
@@ -295,7 +295,7 @@ jobs:
 
       - name: Canary - Upload e2e test summary
         uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@gh-pages
-        if: ${{ always() && !cancelled() }}
+        if: ${{ always() && steps.canary-version-tests.outcome == 'failure' }}
         with:
           report-dir: ${{ matrix.pluginDir }}/playwright-report
           grafana-version: canary

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -187,7 +187,7 @@ jobs:
         run: npm run e2e --prefix ${{ matrix.pluginDir }}
 
       - name: Expected - Upload e2e test summary
-        uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@gh-pages
+        uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@main
         if: ${{ always() && steps.expected-version-tests.outcome == 'failure' }}
         with:
           report-dir: ${{ matrix.pluginDir }}/playwright-report
@@ -228,7 +228,7 @@ jobs:
         run: npm run e2e --prefix ${{ matrix.pluginDir }}
 
       - name: Latest - Upload e2e test summary
-        uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@gh-pages
+        uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@main
         if: ${{ always() && steps.latest-version-tests.outcome == 'failure' }}
         with:
           report-dir: ${{ matrix.pluginDir }}/playwright-report
@@ -294,7 +294,7 @@ jobs:
         run: npm run e2e --prefix ${{ matrix.pluginDir }}
 
       - name: Canary - Upload e2e test summary
-        uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@gh-pages
+        uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@main
         if: ${{ always() && steps.canary-version-tests.outcome == 'failure' }}
         with:
           report-dir: ${{ matrix.pluginDir }}/playwright-report
@@ -326,7 +326,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Publish report
-        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@gh-pages
+        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,13 +2,15 @@ name: integration tests
 on:
   pull_request:
   schedule:
-    - cron: "0 11 * * *" #once a day at 11 UTC
+    - cron: '0 11 * * *' #once a day at 11 UTC
 concurrency:
   group: integration-tests-${{ github.ref }}
   cancel-in-progress: true
 permissions:
-  contents: read
+  contents: write
   id-token: write
+  pull-requests: write
+
 jobs:
   setup-matrix:
     runs-on: ubuntu-latest
@@ -49,11 +51,11 @@ jobs:
         pluginDir: ${{ fromJson(needs.setup-matrix.outputs.pluginDirs) }}
       fail-fast: false
     env:
-      GF_AUTH_ANONYMOUS_ENABLED: "true"
-      GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
-      GF_AUTH_BASIC_ENABLED: "false"
-      GF_DEFAULT_APP_MODE: "development"
-      GF_INSTALL_PLUGINS: "marcusolsson-static-datasource"
+      GF_AUTH_ANONYMOUS_ENABLED: 'true'
+      GF_AUTH_ANONYMOUS_ORG_ROLE: 'Admin'
+      GF_AUTH_BASIC_ENABLED: 'false'
+      GF_DEFAULT_APP_MODE: 'development'
+      GF_INSTALL_PLUGINS: 'marcusolsson-static-datasource'
     steps:
       - uses: actions/checkout@v4
 
@@ -65,9 +67,9 @@ jobs:
       - name: Setup node version
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-          cache: "npm"
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
 
       - name: Install dependencies
         run: |
@@ -92,7 +94,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "~1.22"
+          go-version: '~1.22'
           check-latest: true
           cache-dependency-path: ${{ matrix.pluginDir }}/go.sum
         if: steps.backend-check.outputs.MAGEFILE_EXISTS == 'true'
@@ -173,7 +175,7 @@ jobs:
         if: steps.has-integration-tests.outputs.DIR == 'true' && steps.should-run-expected-latest-tests.outcome == 'success'
         uses: nev7n/wait_for_response@v1
         with:
-          url: "http://localhost:3000/"
+          url: 'http://localhost:3000/'
           responseCode: 200
           timeout: 60000
           interval: 500
@@ -184,16 +186,16 @@ jobs:
         continue-on-error: true
         run: npm run e2e --prefix ${{ matrix.pluginDir }}
 
-      - name: Expected - Publish report to GCS
-        if: ${{ always() && steps.expected-version-tests.outcome == 'failure' }}
-        uses: grafana/plugin-actions/publish-report@main
+      - name: Expected - Upload e2e test summary
+        uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@gh-pages
+        if: ${{ always() && !cancelled() }}
         with:
+          report-dir: ${{ matrix.pluginDir }}/playwright-report
           grafana-version: ${{ env.EXPECTED_GRAFANA_VERSION }}
-          path: ${{ matrix.pluginDir }}/playwright-report/
-
-      - name: Expected - Failing build due to test failures
-        if: steps.has-integration-tests.outputs.DIR == 'true' && steps.expected-version-tests.outcome != 'success'  && steps.should-run-expected-latest-tests.outcome == 'success'
-        run: exit 1
+          grafana-image: grafana-enterprise
+          plugin-name: ${{ env.PLUGIN_ID }}
+          test-outcome: ${{ steps.expected-version-tests.outcome }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Expected - Stop and remove Docker container
         if: steps.has-integration-tests.outputs.DIR == 'true' && steps.should-run-expected-latest-tests.outcome == 'success'
@@ -214,7 +216,7 @@ jobs:
         if: steps.has-integration-tests.outputs.DIR == 'true' && steps.should-run-expected-latest-tests.outcome == 'success'
         uses: nev7n/wait_for_response@v1
         with:
-          url: "http://localhost:3000/"
+          url: 'http://localhost:3000/'
           responseCode: 200
           timeout: 60000
           interval: 500
@@ -225,16 +227,16 @@ jobs:
         continue-on-error: true
         run: npm run e2e --prefix ${{ matrix.pluginDir }}
 
-      - name: Latest - Publish report to GCS
-        if: ${{ always() && steps.latest-version-tests.outcome == 'failure' }}
-        uses: grafana/plugin-actions/publish-report@main
+      - name: Latest - Upload e2e test summary
+        uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@gh-pages
+        if: ${{ always() && !cancelled() }}
         with:
-          grafana-version: ${{ env.LATEST_STABLE_VERSION }}
-          path: ${{ matrix.pluginDir }}/playwright-report/
-
-      - name: Latest - Failing build due to test failures (latest version of Grafana)
-        if: steps.has-integration-tests.outputs.DIR == 'true' && steps.latest-version-tests.outcome != 'success' && steps.should-run-expected-latest-tests.outcome == 'success'
-        run: exit 1
+          report-dir: ${{ matrix.pluginDir }}/playwright-report
+          grafana-version: latest
+          grafana-image: grafana-enterprise
+          plugin-name: ${{ env.PLUGIN_ID }}
+          test-outcome: ${{ steps.latest-version-tests.outcome }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Latest - Stop and remove Docker container
         if: steps.has-integration-tests.outputs.DIR == 'true' && steps.should-run-expected-latest-tests.outcome == 'success'
@@ -280,7 +282,7 @@ jobs:
         if: steps.has-integration-tests.outputs.DIR == 'true'
         uses: nev7n/wait_for_response@v1
         with:
-          url: "http://localhost:3000/"
+          url: 'http://localhost:3000/'
           responseCode: 200
           timeout: 60000
           interval: 500
@@ -291,16 +293,16 @@ jobs:
         continue-on-error: true
         run: npm run e2e --prefix ${{ matrix.pluginDir }}
 
-      - name: Canary - Publish report to GCS
-        if: ${{ always() && steps.canary-version-tests.outcome == 'failure' }}
-        uses: grafana/plugin-actions/publish-report@main
+      - name: Canary - Upload e2e test summary
+        uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@gh-pages
+        if: ${{ always() && !cancelled() }}
         with:
-          grafana-version: ${{ env.CANARY_DOCKER_TAG }}
-          path: ${{ matrix.pluginDir }}/playwright-report/
-
-      - name: Canary - Failing build due to test failures (canary versions)
-        if: steps.has-integration-tests.outputs.DIR == 'true' && steps.canary-version-tests.outcome != 'success'
-        run: exit 1
+          report-dir: ${{ matrix.pluginDir }}/playwright-report
+          grafana-version: canary
+          grafana-image: grafana-enterprise
+          plugin-name: ${{ env.PLUGIN_ID }}
+          test-outcome: ${{ steps.canary-version-tests.outcome }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Canary - Stop and remove Docker container
         if: steps.has-integration-tests.outputs.DIR == 'true'
@@ -312,6 +314,21 @@ jobs:
         if: steps.mockserver-check.outputs.MOCKSERVER_DEFINED == 'true'
         run: docker compose down mockserver
         working-directory: ${{ matrix.pluginDir }}
+
+      - name: Failing build due to test failures
+        if: (steps.has-integration-tests.outputs.DIR == 'true' && (steps.canary-version-tests.outcome != 'success' || steps.latest-version-tests.outcome != 'success' || steps.expected-version-tests.outcome != 'success'))
+        run: exit 1
+
+  publish-report:
+    if: ${{ always() }}
+    needs: [run-integration-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish report
+        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@gh-pages
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   notify:
     if: ${{ (always() && github.event_name == 'schedule') }}

--- a/examples/datasource-http/tests/queryEditor.spec.ts
+++ b/examples/datasource-http/tests/queryEditor.spec.ts
@@ -1,6 +1,7 @@
+import * as semver from 'semver';
 import { test, expect } from '@grafana/plugin-e2e';
 
-test('data query should return a value', async ({ panelEditPage, readProvisionedDataSource }) => {
+test('data query should return a value', async ({ panelEditPage, readProvisionedDataSource, grafanaVersion }) => {
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
   await panelEditPage.datasource.set(ds.name);
   await panelEditPage.setVisualization('Table');
@@ -8,4 +9,7 @@ test('data query should return a value', async ({ panelEditPage, readProvisioned
   await panelEditPage.getQueryEditorRow('A').getByRole('spinbutton').fill('10');
   await expect(panelEditPage.panel.fieldNames).toContainText(['Time', 'Value']);
   await expect(panelEditPage.panel.data).toContainText(['10']);
+  if (semver.gte(grafanaVersion, '11.5.0')) {
+    await expect(panelEditPage).toHaveAlert('error', { hasText: 'Path is required' });
+  }
 });

--- a/examples/datasource-http/tests/queryEditor.spec.ts
+++ b/examples/datasource-http/tests/queryEditor.spec.ts
@@ -1,7 +1,6 @@
-import * as semver from 'semver';
 import { test, expect } from '@grafana/plugin-e2e';
 
-test('data query should return a value', async ({ panelEditPage, readProvisionedDataSource, grafanaVersion }) => {
+test('data query should return a value', async ({ panelEditPage, readProvisionedDataSource }) => {
   const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
   await panelEditPage.datasource.set(ds.name);
   await panelEditPage.setVisualization('Table');
@@ -9,7 +8,4 @@ test('data query should return a value', async ({ panelEditPage, readProvisioned
   await panelEditPage.getQueryEditorRow('A').getByRole('spinbutton').fill('10');
   await expect(panelEditPage.panel.fieldNames).toContainText(['Time', 'Value']);
   await expect(panelEditPage.panel.data).toContainText(['10']);
-  if (semver.gte(grafanaVersion, '11.5.0')) {
-    await expect(panelEditPage).toHaveAlert('error', { hasText: 'Path is required' });
-  }
 });


### PR DESCRIPTION
This PR uses the [new actions](https://github.com/grafana/plugin-actions/pull/50) to publish Playwright reports to GH pages. Too see the test result matrix including links to GH Pages, see the [previous test run](https://github.com/grafana/grafana-plugin-examples/actions/runs/13075183300/attempts/1#summary-36485782273) where tests were forced to fail. 