### PR TITLE
App with dashboards: Fix failing e2e test

### DIFF
--- a/examples/app-with-dashboards/tests/appNavigation.spec.ts
+++ b/examples/app-with-dashboards/tests/appNavigation.spec.ts
@@ -9,12 +9,12 @@ test.describe('navigating app', () => {
   test('should be possible to navigate to example dashboard 1', async ({ gotoPage, page }) => {
     await gotoPage('/');
     await page.getByText('Example dashboard 1').click();
-    await expect(page).toHaveURL(/\/d\/Av57mRHVz$/);
+    await expect(page).toHaveURL(/\/d\/Av57mRHVz\//);
   });
 
   test('should be possible to navigate to example dashboard 2', async ({ gotoPage, page }) => {
     await gotoPage('/');
     await page.getByText('Example dashboard 2').click();
-    await expect(page).toHaveURL(/\/d\/ND1Bfw3VcNGg$/);
+    await expect(page).toHaveURL(/\/d\/ND1Bfw3VcNGg\//);
   });
 });


### PR DESCRIPTION
We've a failing e2e test due to regex that likely should never have matched properly. Looks like someone fixed the implementation in playwright and the bump to 1.50.1 surfaced the issue.