### PR TITLE
Feat: Adding signed commits flag to create PR action

### DIFF
--- a/.github/workflows/automatic-update.yml
+++ b/.github/workflows/automatic-update.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PEM }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PEM }}
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -43,6 +43,7 @@ jobs:
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           delete-branch: true
           commit-message: "chore: update configuration to latest version"
+          sign-commits: true
           title: "Chore: Bump plugin-examples configuration to latest version"
           body: |
             Bumps [`grafana-plugin-examples`](https://github.com/grafana/grafana-plugin-examples) configuration to the latest version.

--- a/examples/app-with-backend/tests/appCallingBackend.spec.ts
+++ b/examples/app-with-backend/tests/appCallingBackend.spec.ts
@@ -1,15 +1,16 @@
+import { testIds } from "../src/components/testIds";
 import { test, expect } from "./fixtures";
 
 test("page one should successfully call backend and display reply", async ({
   pageOne,
   page,
 }) => {
-  await expect(page.getByText("pong")).toBeVisible();
+  await expect(page.getByTestId(testIds.pageOne.ping).getByText("pong")).toBeVisible();
 });
 
 test("page one should succesfully check health and display status", async ({
   pageOne,
   page,
-}) => {
-  await expect(page.getByText("OK")).toBeVisible();
+}) => {  
+  await expect(page.getByTestId(testIds.pageOne.health).getByText("OK")).toBeVisible();
 });


### PR DESCRIPTION
Changes:
- Trying out if signed commits actually work with create pull request action
- Switching from `tibdex/github-app-token` to `actions/create-github-app-token` as it an official app by github