### PR TITLE
Chore: Ignore author field

### DIFF
--- a/.github/workflows/automatic-update.yml
+++ b/.github/workflows/automatic-update.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
           branch: new-update-plugin-examples
-          #  Author field is ignored when commit-message is set to true
+          #  Author field is ignored when sign-commits is set to true
           # author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           delete-branch: true
           commit-message: "chore: update configuration to latest version"

--- a/.github/workflows/automatic-update.yml
+++ b/.github/workflows/automatic-update.yml
@@ -40,7 +40,8 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
           branch: new-update-plugin-examples
-          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          #  Author field is ignored when commit-message is set to true
+          # author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           delete-branch: true
           commit-message: "chore: update configuration to latest version"
           sign-commits: true


### PR DESCRIPTION
From the `peter-evans/create-pull-request` docs: 

https://github.com/peter-evans/create-pull-request/blob/a7b20e1da215b3ef3ccddb48ff65120256ed6226/docs/concepts-guidelines.md?plain=1#L378

> When setting `sign-commits: true` the action will ignore the `committer` and `author` inputs.

This PR comments out the `author` field to make sure only the fields that are used are actually set - less overall confusion.