### PR TITLE
CI: Use Vault

### DIFF
--- a/.github/workflows/automatic-update.yml
+++ b/.github/workflows/automatic-update.yml
@@ -54,6 +54,8 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
           branch: new-update-plugin-examples
+          # If running this workflow via a workflow_dispatch event, we want to target the main branch
+          base: main
           #  Author field is ignored when sign-commits is set to true
           # author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           delete-branch: true

--- a/.github/workflows/automatic-update.yml
+++ b/.github/workflows/automatic-update.yml
@@ -10,13 +10,22 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # get-vault-secrets-v1.1.0
+        with:
+          # Secrets placed in the ci/repo/grafana/grafana-plugin-examples path in Vault
+          repo_secrets: |
+            GITHUB_APP_ID=plugins-platform-bot-app:app_id
+            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:app_pem
+
       - name: Generate token
         id: generate_token
         uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PEM }}
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/automatic-update.yml
+++ b/.github/workflows/automatic-update.yml
@@ -70,11 +70,11 @@ jobs:
         run: gh pr merge $PR_URL --auto --squash
         env:
           PR_URL: https://github.com/grafana/grafana-plugin-examples/pull/${{ steps.create_pr.outputs.pull-request-number }}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Auto approve PR
         if: steps.status.outputs.has_changes == 'true'
         run: gh pr review $PR_URL --approve -b "Approving update"
         env:
           PR_URL: https://github.com/grafana/grafana-plugin-examples/pull/${{ steps.create_pr.outputs.pull-request-number }}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/automatic-update.yml
+++ b/.github/workflows/automatic-update.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
       id-token: write
     steps:
       - id: get-secrets
@@ -70,11 +71,11 @@ jobs:
         run: gh pr merge $PR_URL --auto --squash
         env:
           PR_URL: https://github.com/grafana/grafana-plugin-examples/pull/${{ steps.create_pr.outputs.pull-request-number }}
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Auto approve PR
         if: steps.status.outputs.has_changes == 'true'
         run: gh pr review $PR_URL --approve -b "Approving update"
         env:
           PR_URL: https://github.com/grafana/grafana-plugin-examples/pull/${{ steps.create_pr.outputs.pull-request-number }}
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/automatic-update.yml
+++ b/.github/workflows/automatic-update.yml
@@ -9,7 +9,7 @@ jobs:
   update-grafana:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       id-token: write
     steps:


### PR DESCRIPTION
Looks like the auto grafana update workflow is [failing at token generation](https://github.com/grafana/grafana-plugin-examples/actions/runs/14791363677/job/41529043807).

This PR replaces the usage of gh secrets with vault which should solve this issue. [Workflow run using this branch here](https://github.com/grafana/grafana-plugin-examples/actions/runs/14796392873).


Once merged I'll delete the secrets. 🔪🔪🔪 