### PR TITLE
CI: Fix lapo docs notify plugin tools workflow

### DIFF
--- a/.github/workflows/notify-plugin-tools.yml
+++ b/.github/workflows/notify-plugin-tools.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   notify-plugin-tools:


### PR DESCRIPTION
Adds `id-token: write` so workflow gets its secrets.