### PR TITLE
Chore: Harden github token permissions

### DIFF
--- a/.github/workflows/notify-plugin-tools.yml
+++ b/.github/workflows/notify-plugin-tools.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           app-id: ${{ env.GITHUB_APP_ID }}
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Repository Dispatch
         if: steps.check_files.outputs.has_relevant_changes == 'true'


### PR DESCRIPTION
This PR gives the github token used in CI only the minimum required permissions.
Part of https://github.com/grafana/grafana-community-team/issues/429
