### PR TITLE
Chore: Use get-vault-secrets without exporting env variables

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -358,7 +358,7 @@ jobs:
       id-token: write
     steps:
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # get-vault-secrets-v1.1.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1 # zizmor: ignore[unpinned-uses] provided by grafana
         with:
           export_env: false
           # Secrets placed in the ci/repo/grafana/grafana-plugin-examples path in Vault

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -360,6 +360,7 @@ jobs:
       - id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # get-vault-secrets-v1.1.0
         with:
+          export_env: false
           # Secrets placed in the ci/repo/grafana/grafana-plugin-examples path in Vault
           repo_secrets: |
             SLACK_WEBHOOK_URL=slack_webhook_url:slack_webhook_url
@@ -427,5 +428,5 @@ jobs:
                 ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ fromJSON(steps.get-secrets.outputs.secrets).SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/notify-plugin-tools.yml
+++ b/.github/workflows/notify-plugin-tools.yml
@@ -35,8 +35,9 @@ jobs:
           COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
 
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # get-vault-secrets-v1.1.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1 # zizmor: ignore[unpinned-uses] provided by grafana
         with:
+          export_env: false
           # Secrets placed in the ci/repo/grafana/grafana-plugin-examples path in Vault
           repo_secrets: |
             GITHUB_APP_ID=plugins-platform-bot-app:app_id
@@ -47,8 +48,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
+          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PEM }}
           permission-contents: write
 
       - name: Repository Dispatch


### PR DESCRIPTION
Moves the usage of get-vault-secrets to use step outputs instead of global env variables