### PR TITLE
chore(update-examples): migrate token generation to GATB

### DIFF
--- a/.github/workflows/update-examples.yaml
+++ b/.github/workflows/update-examples.yaml
@@ -20,20 +20,12 @@ jobs:
           # require for PR action
           persist-credentials: true
 
-      - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f1614b210386ac420af6807a997ac7f6d96e477a # get-vault-secrets/v1.3.1
-        with:
-          repo_secrets: |
-            GITHUB_APP_ID=plugins-platform-bot-app:app_id
-            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:app_pem
-
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - name: Generate GitHub token
         id: generate_token
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
+          github_app: grafana-plugins-platform-bot
+          permission_set: update-examples
 
       - name: Setup nodejs 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Summary

Migrates `.github/workflows/update-examples.yaml` off the long-lived `grafana-plugins-platform-bot` token (Vault `get-vault-secrets` + `actions/create-github-app-token`) onto the short-lived **GATB** (GitHub App Token Broker) flow via `grafana/shared-workflows/actions/create-github-app-token`.

Why: per the [plugins-platform GATB migration](https://github.com/grafana/grafana-catalog-team/blob/main/docs/plugins-ci-github-actions/070-gatb-migration.md), the long-lived bot token will be revoked. Workflows that use it must switch to GATB or stop working.

What changes:
- Drop the `get-secrets` (Vault) step.
- Replace `actions/create-github-app-token@v3.0.0` with `grafana/shared-workflows/actions/create-github-app-token@create-github-app-token/v0.2.3`, asking for the `update-examples` permission set.
- Downstream `peter-evans/create-pull-request` is unchanged — it still reads `steps.generate_token.outputs.token` to push the update branch and open the PR.

## Companion PR (must merge first)

[grafana/deployment_tools#592603](https://github.com/grafana/deployment_tools/pull/592603) — adds the matching GATB config at `terraform/repositories/grafana-plugin-examples/github-app-configs/config.yaml`. Without it merged **and `atlantis apply`'d**, the next scheduled run will 403 / hit a "role not found" error.

Order:
1. Merge deployment_tools PR (via `atlantis apply`).
2. Merge this PR.

`grafana/grafana-plugin-examples` is already in `plugins-platform-bot-users.txt`, so no IT ticket needed.

## Test plan

- [ ] After deployment_tools PR is applied + this PR merged, trigger `update-examples.yaml` via `workflow_dispatch` and confirm the token is minted, examples regenerate, and the PR is opened.
- [ ] Confirm next Sunday-midnight `schedule` run also succeeds end-to-end.