### PR TITLE
Add sign-commits to update-examples workflow

### DIFF
--- a/.github/workflows/update-examples.yaml
+++ b/.github/workflows/update-examples.yaml
@@ -85,4 +85,5 @@ jobs:
           delete-branch: true
           base: main
           token: ${{ steps.generate_token.outputs.token }}
+          sign-commits: true
 


### PR DESCRIPTION
Add `sign-commits: true` to the peter-evans/create-pull-request step in update-examples workflow

Fix: #680 