### PR TITLE
ci: temporarily disable playwright report publishing

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -299,21 +299,23 @@ jobs:
         if: (steps.has-integration-tests.outputs.DIR == 'true' && (steps.canary-version-tests.outcome != 'success' || steps.latest-version-tests.outcome != 'success' || steps.expected-version-tests.outcome != 'success'))
         run: exit 1
 
-  publish-report:
-    if: ${{ always() }}
-    needs: [run-integration-tests]
-    permissions:
-      contents: write
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - name: Publish report
-        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@main # zizmor: ignore[unpinned-uses]
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+  # TEMP DISABLED 2026-06-18: deploy-report-pages pushes an unsigned commit to gh-pages,
+  # which will be rejected once unsigned commits are blocked. Re-enable once resolved.
+  # publish-report:
+  #   if: ${{ always() }}
+  #   needs: [run-integration-tests]
+  #   permissions:
+  #     contents: write
+  #     pull-requests: write
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+  #       with:
+  #         persist-credentials: false
+  #     - name: Publish report
+  #       uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@main # zizmor: ignore[unpinned-uses]
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
 
   notify:
     if: ${{ (always() && github.event_name == 'schedule') }}


### PR DESCRIPTION
The `deploy-report-pages` action pushes an unsigned commit to `gh-pages`, which will be rejected once unsigned commits are blocked. Comments out the `publish-report` job in integration-tests.yml until the signing issue is resolved. `upload-report-artifacts` is untouched.