### PR TITLE
chore(renovate): drop redundant rules, automerge lockfile PRs

### DIFF
--- a/.github/workflows/renovate-approve.yml
+++ b/.github/workflows/renovate-approve.yml
@@ -54,7 +54,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve --body "Automated approval: patch, pin, digest or dev dependency update with all CI checks green."
+          gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve --body "Automated approval: patch, pin, digest or lock file maintenance update with all CI checks green."
 
       - name: Checkout
         if: contains(github.event.pull_request.labels.*.name, 'claude-gate')

--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,6 @@
         "github>grafana/grafana-renovate-config//presets/npm"
   ],
   "extends": [
-    ":disableDependencyDashboard",
-    ":preserveSemverRanges",
     "github>grafana/grafana-catalog-team//renovate/renovate"
   ],
   "ignorePaths": [
@@ -25,13 +23,7 @@
     },
     {
       "description": "Automerge pilot: clear-cut updates get a direct bot approval, required CI checks still gate the merge",
-      "matchUpdateTypes": ["patch", "pin", "digest"],
-      "automerge": true,
-      "addLabels": ["automerge-direct"]
-    },
-    {
-      "description": "Automerge pilot: dev dependencies get a direct bot approval, required CI checks still gate the merge",
-      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "pin", "digest", "lockFileMaintenance"],
       "automerge": true,
       "addLabels": ["automerge-direct"]
     }


### PR DESCRIPTION
Same cleanup as grafana/grafana-advisor-app#375:

- The devDependencies rule was a no-op: patch/pin/digest devDeps already got automerge-direct, and minor/major devDeps carried both labels with claude-gate taking precedence in the workflow. Removed, so devDep minors/majors are explicitly Claude-gated.
- Lock file maintenance PRs now get automerge-direct instead of manual merges.
- :disableDependencyDashboard and :preserveSemverRanges came in twice, the team preset already extends both.

Lockstep package families get grouped via group:monorepos in the team preset (grafana/grafana-catalog-team#1088).